### PR TITLE
feat: project and category database schema

### DIFF
--- a/api/src/db/migrations/0004_mushy_manta.sql
+++ b/api/src/db/migrations/0004_mushy_manta.sql
@@ -1,0 +1,40 @@
+CREATE TYPE "public"."access" AS ENUM('open_source', 'closed_source', 'private_beta', 'public_beta');--> statement-breakpoint
+CREATE TYPE "public"."audience" AS ENUM('students', 'developers', 'businesses', 'government', 'general_public');--> statement-breakpoint
+CREATE TYPE "public"."businessModel" AS ENUM('b2b', 'b2c', 'b2g', 'c2c', 'nonprofit');--> statement-breakpoint
+CREATE TYPE "public"."platform" AS ENUM('web', 'mobile', 'desktop', 'api', 'other');--> statement-breakpoint
+CREATE TYPE "public"."pricing" AS ENUM('free', 'freemium', 'paid');--> statement-breakpoint
+CREATE TYPE "public"."projectStage" AS ENUM('idea', 'development', 'mvp', 'launched', 'growth', 'maintenance', 'archived');--> statement-breakpoint
+CREATE TABLE "categories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"key" varchar NOT NULL,
+	"name" varchar NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "categories_key_unique" UNIQUE("key")
+);
+--> statement-breakpoint
+CREATE TABLE "projects" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"publisher_id" integer NOT NULL,
+	"name" varchar NOT NULL,
+	"slug" text NOT NULL,
+	"short_description" varchar NOT NULL,
+	"description" text,
+	"website_url" text NOT NULL,
+	"logo_url" text,
+	"banner_image_url" text,
+	"github_url" text,
+	"pricing" "pricing" NOT NULL,
+	"platform" "platform"[] NOT NULL,
+	"businessModel" "businessModel" NOT NULL,
+	"access" "access" NOT NULL,
+	"projectStage" "projectStage" NOT NULL,
+	"audience" "audience" NOT NULL,
+	"category_id" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "projects_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_publisher_id_publishers_id_fk" FOREIGN KEY ("publisher_id") REFERENCES "public"."publishers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_category_id_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."categories"("id") ON DELETE restrict ON UPDATE no action;

--- a/api/src/db/migrations/meta/0004_snapshot.json
+++ b/api/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,801 @@
+{
+  "id": "7ff0c52e-cba0-4f1a-98c2-af0d9372c129",
+  "prevId": "c126e8b3-fcda-408f-b0e1-c12ad058d34c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_key_unique": {
+          "name": "categories_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_image_url": {
+          "name": "banner_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "pricing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "businessModel": {
+          "name": "businessModel",
+          "type": "businessModel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access": {
+          "name": "access",
+          "type": "access",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectStage": {
+          "name": "projectStage",
+          "type": "projectStage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_publisher_id_publishers_id_fk": {
+          "name": "projects_publisher_id_publishers_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_category_id_categories_id_fk": {
+          "name": "projects_category_id_categories_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_response": {
+          "name": "profile_response",
+          "type": "profile_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_response": {
+          "name": "objective_response",
+          "type": "objective_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_response": {
+          "name": "location_response",
+          "type": "location_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "found_us_by_response": {
+          "name": "found_us_by_response",
+          "type": "found_us_by_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publisher_user_idx": {
+          "name": "publisher_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publishers_user_id_users_id_fk": {
+          "name": "publishers_user_id_users_id_fk",
+          "tableFrom": "publishers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access": {
+      "name": "access",
+      "schema": "public",
+      "values": [
+        "open_source",
+        "closed_source",
+        "private_beta",
+        "public_beta"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "students",
+        "developers",
+        "businesses",
+        "government",
+        "general_public"
+      ]
+    },
+    "public.businessModel": {
+      "name": "businessModel",
+      "schema": "public",
+      "values": [
+        "b2b",
+        "b2c",
+        "b2g",
+        "c2c",
+        "nonprofit"
+      ]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": [
+        "web",
+        "mobile",
+        "desktop",
+        "api",
+        "other"
+      ]
+    },
+    "public.pricing": {
+      "name": "pricing",
+      "schema": "public",
+      "values": [
+        "free",
+        "freemium",
+        "paid"
+      ]
+    },
+    "public.projectStage": {
+      "name": "projectStage",
+      "schema": "public",
+      "values": [
+        "idea",
+        "development",
+        "mvp",
+        "launched",
+        "growth",
+        "maintenance",
+        "archived"
+      ]
+    },
+    "public.found_us_by_responses": {
+      "name": "found_us_by_responses",
+      "schema": "public",
+      "values": [
+        "social-media",
+        "friends",
+        "event",
+        "online-search"
+      ]
+    },
+    "public.location_responses": {
+      "name": "location_responses",
+      "schema": "public",
+      "values": [
+        "CV1",
+        "CV2",
+        "CV3",
+        "CV4",
+        "CV5",
+        "CV6",
+        "CV7",
+        "CV8",
+        "CV9",
+        "diaspora"
+      ]
+    },
+    "public.objective_responses": {
+      "name": "objective_responses",
+      "schema": "public",
+      "values": [
+        "discover-products",
+        "launch-product",
+        "networking",
+        "explore"
+      ]
+    },
+    "public.profile_responses": {
+      "name": "profile_responses",
+      "schema": "public",
+      "values": [
+        "student",
+        "technology-professional",
+        "founder",
+        "investor"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/db/migrations/meta/_journal.json
+++ b/api/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1760308279131,
       "tag": "0003_busy_doctor_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786803764907,
+      "tag": "0004_mushy_manta",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/db/schemas/projects.ts
+++ b/api/src/db/schemas/projects.ts
@@ -15,6 +15,7 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 import { categories } from "./categories";
+import { publishers } from "./publishers";
 import { timestamps } from "./timestamps";
 
 export const pricingEnum = pgEnum("pricing", pricingValues);
@@ -26,22 +27,26 @@ export const audienceStageEnum = pgEnum("audience", audienceValues);
 
 export const projects = pgTable("projects", {
   id: serial("id").primaryKey(),
+  publisherId: integer("publisher_id")
+    .notNull()
+    .references(() => publishers.id, { onDelete: "cascade" }),
   name: varchar("name").notNull(),
   slug: text("slug").notNull().unique(),
   shortDescription: varchar("short_description").notNull(),
   description: text("description"),
   websiteUrl: text("website_url").notNull(),
-  logoUrl: text("logo_url").notNull(),
+  logoUrl: text("logo_url"),
   bannerImageUrl: text("banner_image_url"),
   githubUrl: text("github_url"),
   pricing: pricingEnum("pricing").notNull(),
+  platform: platformEnum("platform").array().notNull(),
   businessModel: businessModelEnum("businessModel").notNull(),
   access: accessEnum("access").notNull(),
   projectStage: projectStageEnum("projectStage").notNull(),
-  audienceStage: projectStageEnum("audience").notNull(),
-  categoryId: integer("id")
+  audienceStage: audienceStageEnum("audience").notNull(),
+  categoryId: integer("category_id")
     .notNull()
-    .references(() => categories.id, { onDelete: "set null" }),
+    .references(() => categories.id, { onDelete: "restrict" }),
 
   ...timestamps,
 });

--- a/api/src/db/schemas/relations.ts
+++ b/api/src/db/schemas/relations.ts
@@ -11,11 +11,12 @@ export const userRelations = relations(users, ({ one }) => ({
   }),
 }));
 
-export const publisherRelations = relations(publishers, ({ one }) => ({
+export const publisherRelations = relations(publishers, ({ one, many }) => ({
   user: one(users, {
     fields: [publishers.userId],
     references: [users.id],
   }),
+  projects: many(projects),
 }));
 
 export const projectRelations = relations(projects, ({ one }) => ({
@@ -23,11 +24,12 @@ export const projectRelations = relations(projects, ({ one }) => ({
     fields: [projects.categoryId],
     references: [categories.id],
   }),
+  publisher: one(publishers, {
+    fields: [projects.publisherId],
+    references: [publishers.id],
+  }),
 }));
 
-export const categoriesRelations = relations(categories, ({ one }) => ({
-  project: one(projects, {
-    fields: [categories.id],
-    references: [projects.categoryId],
-  }),
+export const categoriesRelations = relations(categories, ({ many }) => ({
+  projects: many(projects),
 }));

--- a/api/src/db/seeds/categories.ts
+++ b/api/src/db/seeds/categories.ts
@@ -3,38 +3,41 @@ import { logger } from "@/utils/logger";
 import { categories } from "../schemas";
 
 export const categoryType = {
-    ai: "Inteligência Artificial",
-    health: "Saúde",
-    education: "Educação",
-    fintech: "Tecnologia Financeira",
-    social: "Social",
-    travel: "Viagens",
-    entertainment: "Entretenimento",
-    ecommerce: "Comércio Eletrônico",
-    environment: "Meio Ambiente",
-    open_source: "Código Aberto",
-    other: "Outros"
+  saas: "SaaS",
+  developer_tools: "Ferramentas para Programadores",
+  ai: "Inteligência Artificial",
+  fintech: "Fintech",
+  ecommerce: "Comércio Eletrónico",
+  productivity: "Produtividade",
+  marketing: "Marketing",
+  design: "Design & Criatividade",
+  data_analytics: "Dados & Analytics",
+  cybersecurity: "Cibersegurança",
+  hr: "Recursos Humanos",
+  logistics: "Logística & Mobilidade",
+  agritech: "Agricultura & Agritech",
+  govtech: "Governo & Cidadania Digital",
+  education: "Educação",
+  health: "Saúde",
+  travel: "Turismo",
+  social: "Social & Comunidade",
+  entertainment: "Entretenimento & Media",
+  environment: "Sustentabilidade & Ambiente",
+  open_source: "Código Aberto",
+  other: "Outros",
 } as const;
 
 export default async function seed(db: DB) {
   try {
-    const exists = await db.query.categories.findFirst({
-      columns: {
-        id: true,
-      },
-    });
-
-    if (exists) {
-      logger.info("Categories already exist. Skipping...");
-      return;
-    }
-
     const values = Object.entries(categoryType).map(([key, name]) => ({
       key,
       name,
     }));
-    
-    await db.insert(categories).values(values);
+
+    await db
+      .insert(categories)
+      .values(values)
+      .onConflictDoNothing({ target: categories.key });
 
     logger.info("Categories seeded successfully.");
   } catch (error) {

--- a/api/src/utils/slugify.ts
+++ b/api/src/utils/slugify.ts
@@ -1,0 +1,9 @@
+export function slugify(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}


### PR DESCRIPTION
## Summary

Second in the series (after #33, which has merged). Pure DB layer, no API surface yet.

- Corrects the `projects` Drizzle schema from `d89f0da`, which had never had a migration generated for it: `categoryId` was pointing at `integer("id")` instead of `category_id`, `audienceStage` reused the `projectStage` enum instead of a dedicated `audience` enum, `logoUrl` was wrongly required, and `publisherId`/`platform` were missing entirely.
- Generates `0004_mushy_manta.sql` — the actual first migration creating `projects`/`categories` (schema existed only in TS before this).
- Adds `publisher <-> project` and `category <-> project` relations.
- Reseeds categories with a fuller taxonomy and switches to `onConflictDoNothing` so re-seeding is idempotent.
- Adds `slugify()`, used by the project-creation endpoint in the next PR.

## Test plan

- [x] `pnpm api:build` passing, verified with the not-yet-landed projects/categories API modules set aside (isolated to just this PR's diff on top of `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)