### PR TITLE
feat: projects and categories API

### DIFF
--- a/api/src/hooks/require-publisher.ts
+++ b/api/src/hooks/require-publisher.ts
@@ -1,0 +1,31 @@
+import { ProjectsService } from "@/modules/projects/projects-services";
+import {
+  PublisherRequiredError,
+  UnauthorizedAccessError,
+} from "@/utils/custom-errors";
+import { FastifyRequest } from "fastify";
+
+type Publisher = NonNullable<
+  Awaited<ReturnType<typeof ProjectsService.findPublisherByUserId>>
+>;
+
+declare module "fastify" {
+  interface FastifyRequest {
+    publisher: Publisher;
+  }
+}
+
+export async function requirePublisher(req: FastifyRequest) {
+  if (!req.user) throw new UnauthorizedAccessError();
+
+  const publisher = await ProjectsService.findPublisherByUserId(
+    req.db,
+    req.user.id
+  );
+
+  if (!publisher) {
+    throw new PublisherRequiredError();
+  }
+
+  req.publisher = publisher;
+}

--- a/api/src/modules/categories/categories-controllers.ts
+++ b/api/src/modules/categories/categories-controllers.ts
@@ -1,0 +1,14 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { CategoriesService } from "./categories-services";
+
+async function listCategoriesHandler(req: FastifyRequest, reply: FastifyReply) {
+  const categories = await CategoriesService.listCategories(req.db);
+
+  return reply.status(200).send({
+    data: categories,
+  });
+}
+
+export const categoriesController = {
+  listCategoriesHandler,
+};

--- a/api/src/modules/categories/categories-routes.ts
+++ b/api/src/modules/categories/categories-routes.ts
@@ -1,0 +1,10 @@
+import { FastifyInstance } from "fastify";
+import { categoriesController } from "./categories-controllers";
+import { listCategoriesRouteSchema } from "./categories-schemas";
+
+export async function categoriesRoutes(server: FastifyInstance) {
+  server.get("/", {
+    schema: listCategoriesRouteSchema,
+    handler: categoriesController.listCategoriesHandler,
+  });
+}

--- a/api/src/modules/categories/categories-schemas.ts
+++ b/api/src/modules/categories/categories-schemas.ts
@@ -1,0 +1,13 @@
+import { routeErrorResponses } from "@/shared/schemas";
+import { categorySummarySchema as categorySchema } from "@hubdigital/shared";
+import { z } from "zod";
+
+export const listCategoriesRouteSchema = {
+  tags: ["categories"],
+  response: {
+    200: z.object({
+      data: z.array(categorySchema),
+    }),
+    ...routeErrorResponses,
+  },
+};

--- a/api/src/modules/categories/categories-services.ts
+++ b/api/src/modules/categories/categories-services.ts
@@ -1,0 +1,17 @@
+import { DB } from "@/db";
+import { categories } from "@/db/schemas";
+import { errorLogger } from "@/utils/error-logger";
+import { asc } from "drizzle-orm";
+
+async function listCategories(db: DB) {
+  return db.query.categories.findMany({
+    orderBy: asc(categories.name),
+  });
+}
+
+export const CategoriesService = {
+  listCategories: errorLogger(
+    listCategories,
+    "categoriesService.listCategories"
+  ),
+};

--- a/api/src/modules/projects/projects-controllers.ts
+++ b/api/src/modules/projects/projects-controllers.ts
@@ -1,0 +1,90 @@
+import { NotFoundError } from "@/utils/custom-errors";
+import {
+  CreateProjectReply,
+  CreateProjectRequest,
+  ListMyProjectsReply,
+  ListMyProjectsRequest,
+  ListProjectsReply,
+  ListProjectsRequest,
+  UpdateProjectReply,
+  UpdateProjectRequest,
+} from "./projects-schemas";
+import { ProjectsService } from "./projects-services";
+
+async function createProjectHandler(
+  req: CreateProjectRequest,
+  reply: CreateProjectReply
+) {
+  const publisher = req.publisher;
+
+  const project = await ProjectsService.createProject(req.db, {
+    ...req.body,
+    publisherId: publisher.id,
+  });
+
+  return reply.status(201).send({
+    data: project,
+  });
+}
+
+async function updateProjectHandler(
+  req: UpdateProjectRequest,
+  reply: UpdateProjectReply
+) {
+  const publisher = req.publisher;
+
+  const project = await ProjectsService.updateProject(
+    req.db,
+    req.params.id,
+    publisher.id,
+    req.body
+  );
+
+  if (!project) {
+    throw new NotFoundError();
+  }
+
+  return reply.status(200).send({
+    data: project,
+  });
+}
+
+async function listMyProjectsHandler(
+  req: ListMyProjectsRequest,
+  reply: ListMyProjectsReply
+) {
+  const publisher = req.publisher;
+
+  const { data, total } = await ProjectsService.listMyProjects(
+    req.db,
+    publisher.id,
+    req.query
+  );
+
+  return reply.status(200).send({
+    data,
+    meta: { limit: req.query.limit, offset: req.query.offset, total },
+  });
+}
+
+async function listProjectsHandler(
+  req: ListProjectsRequest,
+  reply: ListProjectsReply
+) {
+  const { data, total } = await ProjectsService.listProjects(
+    req.db,
+    req.query
+  );
+
+  return reply.status(200).send({
+    data,
+    meta: { limit: req.query.limit, offset: req.query.offset, total },
+  });
+}
+
+export const projectsController = {
+  createProjectHandler,
+  updateProjectHandler,
+  listMyProjectsHandler,
+  listProjectsHandler,
+};

--- a/api/src/modules/projects/projects-routes.ts
+++ b/api/src/modules/projects/projects-routes.ts
@@ -1,0 +1,34 @@
+import { requirePublisher } from "@/hooks/require-publisher";
+import { FastifyInstance } from "fastify";
+import { projectsController } from "./projects-controllers";
+import {
+  createProjectRouteSchema,
+  listMyProjectsRouteSchema,
+  listProjectsRouteSchema,
+  updateProjectRouteSchema,
+} from "./projects-schemas";
+
+export async function projectsRoutes(server: FastifyInstance) {
+  server.post("/", {
+    schema: createProjectRouteSchema,
+    preHandler: requirePublisher,
+    handler: projectsController.createProjectHandler,
+  });
+
+  server.get("/", {
+    schema: listProjectsRouteSchema,
+    handler: projectsController.listProjectsHandler,
+  });
+
+  server.patch("/:id", {
+    schema: updateProjectRouteSchema,
+    preHandler: requirePublisher,
+    handler: projectsController.updateProjectHandler,
+  });
+
+  server.get("/mine", {
+    schema: listMyProjectsRouteSchema,
+    preHandler: requirePublisher,
+    handler: projectsController.listMyProjectsHandler,
+  });
+}

--- a/api/src/modules/projects/projects-schemas.ts
+++ b/api/src/modules/projects/projects-schemas.ts
@@ -1,0 +1,110 @@
+import { errorResponseSchema, routeErrorResponses } from "@/shared/schemas";
+import {
+  projectBodySchema,
+  projectMinimalSchema,
+  projectSchema,
+} from "@hubdigital/shared";
+import { FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+
+export const createProjectRouteSchema = {
+  tags: ["projects"],
+  body: projectBodySchema,
+  response: {
+    201: z.object({
+      data: z.object({
+        id: z.number(),
+        slug: z.string(),
+      }),
+    }),
+    403: errorResponseSchema,
+    ...routeErrorResponses,
+  },
+};
+
+type CreateProjectGeneric = {
+  Body: z.infer<typeof createProjectRouteSchema.body>;
+};
+
+export type CreateProjectRequest = FastifyRequest<CreateProjectGeneric>;
+export type CreateProjectReply = FastifyReply<CreateProjectGeneric>;
+
+export const updateProjectRouteSchema = {
+  tags: ["projects"],
+  params: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  body: projectBodySchema.partial(),
+  response: {
+    200: z.object({
+      data: z.object({
+        id: z.number(),
+        slug: z.string(),
+      }),
+    }),
+    403: errorResponseSchema,
+    ...routeErrorResponses,
+  },
+};
+
+type UpdateProjectGeneric = {
+  Params: z.infer<typeof updateProjectRouteSchema.params>;
+  Body: z.infer<typeof updateProjectRouteSchema.body>;
+};
+
+export type UpdateProjectRequest = FastifyRequest<UpdateProjectGeneric>;
+export type UpdateProjectReply = FastifyReply<UpdateProjectGeneric>;
+
+const paginationMetaSchema = z.object({
+  limit: z.number(),
+  offset: z.number(),
+  total: z.number(),
+});
+
+const paginatedProjectsResponseSchema = z.object({
+  data: z.array(projectSchema),
+  meta: paginationMetaSchema,
+});
+
+const paginatedProjectsMinimalResponseSchema = z.object({
+  data: z.array(projectMinimalSchema),
+  meta: paginationMetaSchema,
+});
+
+const paginationQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+export const listMyProjectsRouteSchema = {
+  tags: ["projects"],
+  querystring: paginationQuerySchema,
+  response: {
+    200: paginatedProjectsResponseSchema,
+    403: errorResponseSchema,
+    ...routeErrorResponses,
+  },
+};
+
+type ListMyProjectsGeneric = {
+  Querystring: z.infer<typeof listMyProjectsRouteSchema.querystring>;
+};
+
+export type ListMyProjectsRequest = FastifyRequest<ListMyProjectsGeneric>;
+export type ListMyProjectsReply = FastifyReply<ListMyProjectsGeneric>;
+
+export const listProjectsRouteSchema = {
+  tags: ["projects"],
+  querystring: paginationQuerySchema,
+  response: {
+    200: paginatedProjectsMinimalResponseSchema,
+    ...routeErrorResponses,
+  },
+};
+
+type ListProjectsGeneric = {
+  Querystring: z.infer<typeof listProjectsRouteSchema.querystring>;
+};
+
+export type ListProjectsRequest = FastifyRequest<ListProjectsGeneric>;
+export type ListProjectsReply = FastifyReply<ListProjectsGeneric>;

--- a/api/src/modules/projects/projects-services.ts
+++ b/api/src/modules/projects/projects-services.ts
@@ -1,0 +1,130 @@
+import { DB } from "@/db";
+import { publishers, projects } from "@/db/schemas";
+import { PG_ERR_UNIQUE_VIOLATION } from "@/utils/constants";
+import { errorLogger } from "@/utils/error-logger";
+import { slugify } from "@/utils/slugify";
+import { and, count, desc, eq } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { PostgresError } from "postgres";
+
+type CreateProjectInput = {
+  publisherId: number;
+  name: string;
+  shortDescription: string;
+  description?: string;
+  websiteUrl: string;
+  githubUrl?: string;
+  pricing: (typeof projects.$inferInsert)["pricing"];
+  platform: (typeof projects.$inferInsert)["platform"];
+  businessModel: (typeof projects.$inferInsert)["businessModel"];
+  access: (typeof projects.$inferInsert)["access"];
+  projectStage: (typeof projects.$inferInsert)["projectStage"];
+  audienceStage: (typeof projects.$inferInsert)["audienceStage"];
+  categoryId: number;
+};
+
+type UpdateProjectInput = Partial<Omit<CreateProjectInput, "publisherId">>;
+
+async function findPublisherByUserId(db: DB, userId: string) {
+  return db.query.publishers.findFirst({
+    where: eq(publishers.userId, userId),
+  });
+}
+
+async function insertProject(db: DB, input: CreateProjectInput, slug: string) {
+  const [result] = await db
+    .insert(projects)
+    .values({ ...input, slug })
+    .returning({ id: projects.id, slug: projects.slug });
+
+  return result;
+}
+
+async function createProject(db: DB, input: CreateProjectInput) {
+  const base = slugify(input.name) || "projeto";
+
+  try {
+    return await insertProject(db, input, base);
+  } catch (error) {
+    if (
+      error instanceof PostgresError &&
+      error.code === PG_ERR_UNIQUE_VIOLATION
+    ) {
+      return await insertProject(
+        db,
+        input,
+        `${base}-${randomUUID().slice(0, 6)}`
+      );
+    }
+
+    throw error;
+  }
+}
+
+async function updateProject(
+  db: DB,
+  id: number,
+  publisherId: number,
+  input: UpdateProjectInput
+) {
+  const [result] = await db
+    .update(projects)
+    .set({ ...input, updatedAt: new Date().toISOString() })
+    .where(and(eq(projects.id, id), eq(projects.publisherId, publisherId)))
+    .returning({ id: projects.id, slug: projects.slug });
+
+  return result;
+}
+
+async function listMyProjects(
+  db: DB,
+  publisherId: number,
+  { limit, offset }: { limit: number; offset: number }
+) {
+  const [data, [{ total }]] = await Promise.all([
+    db.query.projects.findMany({
+      where: eq(projects.publisherId, publisherId),
+      with: { category: true },
+      orderBy: desc(projects.createdAt),
+      limit,
+      offset,
+    }),
+    db
+      .select({ total: count() })
+      .from(projects)
+      .where(eq(projects.publisherId, publisherId)),
+  ]);
+
+  return { data, total };
+}
+
+async function listProjects(
+  db: DB,
+  { limit, offset }: { limit: number; offset: number }
+) {
+  const [data, [{ total }]] = await Promise.all([
+    db.query.projects.findMany({
+      with: { category: true },
+      orderBy: desc(projects.createdAt),
+      limit,
+      offset,
+    }),
+    db.select({ total: count() }).from(projects),
+  ]);
+
+  return { data, total };
+}
+
+export const ProjectsService = {
+  findPublisherByUserId: errorLogger(
+    findPublisherByUserId,
+    "projectsService.findPublisherByUserId"
+  ),
+  createProject: errorLogger(createProject, "projectsService.createProject"),
+  updateProject: errorLogger(updateProject, "projectsService.updateProject"),
+  listMyProjects: errorLogger(
+    listMyProjects,
+    "projectsService.listMyProjects"
+  ),
+  listProjects: errorLogger(listProjects, "projectsService.listProjects"),
+};

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -16,6 +16,8 @@ import {
   ZodTypeProvider,
 } from "fastify-type-provider-zod";
 import { usersRoutes } from "./modules/users/users-routes";
+import { projectsRoutes } from "./modules/projects/projects-routes";
+import { categoriesRoutes } from "./modules/categories/categories-routes";
 import { config } from "./config";
 import betterAuth from "./plugins/better-auth";
 
@@ -67,6 +69,8 @@ export async function buildServer(db: DB) {
   });
 
   await server.register(usersRoutes, { prefix: "/v1/users" });
+  await server.register(projectsRoutes, { prefix: "/v1/projects" });
+  await server.register(categoriesRoutes, { prefix: "/v1/categories" });
 
   server.get("/", async (req: FastifyRequest, reply: FastifyReply) => {
     reply.redirect("/docs");

--- a/api/tests/e2e/projects.test.ts
+++ b/api/tests/e2e/projects.test.ts
@@ -1,0 +1,597 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { PostgreSqlContainer } from "@testcontainers/postgresql";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import type { FastifyInstance } from "fastify";
+import "../setup-env";
+import { setupDB, teardownDB } from "../../src/db";
+import { categories, projects, publishers, users } from "@/db/schemas";
+import { buildServer } from "@/server";
+import { eq } from "drizzle-orm";
+
+const { getSessionMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+}));
+
+vi.mock("../../src/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: getSessionMock,
+      updateUser: vi.fn(),
+    },
+    handler: vi.fn(),
+  },
+}));
+
+const migrationsFolder = join(__dirname, "../../src/db/migrations");
+
+const validProjectPayload = {
+  name: "Hub Digital",
+  shortDescription: "Uma plataforma para descobrir projetos digitais de CV",
+  websiteUrl: "https://hubdigital.cv",
+  pricing: "free",
+  platform: ["web"],
+  businessModel: "b2c",
+  access: "public_beta",
+  projectStage: "mvp",
+  audienceStage: "general_public",
+} as const;
+
+describe("Projects module (e2e)", () => {
+  let container: Awaited<ReturnType<PostgreSqlContainer["start"]>>;
+  let connectionUri: string;
+
+  let dbClient: Awaited<ReturnType<typeof setupDB>>["dbClient"];
+  let db: Awaited<ReturnType<typeof setupDB>>["db"];
+  let server: FastifyInstance;
+  let currentUserId: string;
+  let categoryId: number;
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("postgres:17").start();
+    connectionUri = container.getConnectionUri();
+
+    process.env.DATABASE_URL = connectionUri;
+
+    const setupResult = await setupDB(connectionUri, { migrating: true });
+    await migrate(setupResult.db, { migrationsFolder });
+    await teardownDB(setupResult.dbClient);
+  });
+
+  beforeEach(async () => {
+    getSessionMock.mockReset();
+
+    const setupResult = await setupDB(connectionUri);
+    db = setupResult.db;
+    dbClient = setupResult.dbClient;
+
+    await db.delete(projects);
+    await db.delete(publishers);
+    await db.delete(users);
+    await db.delete(categories);
+
+    currentUserId = randomUUID();
+    await db.insert(users).values({
+      id: currentUserId,
+      name: "Test User",
+      email: `test-${currentUserId}@example.com`,
+      role: "user",
+    });
+
+    const [category] = await db
+      .insert(categories)
+      .values({ key: "ai", name: "Inteligência Artificial" })
+      .returning({ id: categories.id });
+    categoryId = category.id;
+
+    server = await buildServer(db);
+    await server.ready();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+    }
+
+    if (dbClient) {
+      await teardownDB(dbClient);
+    }
+
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    if (container) {
+      await container.stop();
+    }
+  });
+
+  describe("POST /v1/projects", () => {
+    it("rejects project creation when the user is unauthenticated", async () => {
+      getSessionMock.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/v1/projects",
+        payload: { ...validProjectPayload, categoryId },
+      });
+
+      expect(response.statusCode).toBe(401);
+
+      const projectRecords = await db.query.projects.findMany();
+      expect(projectRecords).toHaveLength(0);
+    });
+
+    it("rejects project creation when the user has no publisher profile", async () => {
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/v1/projects",
+        payload: { ...validProjectPayload, categoryId },
+      });
+
+      expect(response.statusCode).toBe(403);
+
+      const projectRecords = await db.query.projects.findMany();
+      expect(projectRecords).toHaveLength(0);
+    });
+
+    it("creates a project for an onboarded user and returns its slug", async () => {
+      const [publisher] = await db
+        .insert(publishers)
+        .values({
+          userId: currentUserId,
+          bio: "Building things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV1",
+          foundUsByResponse: "social-media",
+        })
+        .returning({ id: publishers.id });
+
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/v1/projects",
+        payload: { ...validProjectPayload, categoryId },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      expect(body.data.id).toEqual(expect.any(Number));
+      expect(body.data.slug).toBe("hub-digital");
+
+      const project = await db.query.projects.findFirst({
+        where: eq(projects.id, body.data.id),
+      });
+
+      expect(project).toMatchObject({
+        publisherId: publisher.id,
+        name: validProjectPayload.name,
+        slug: "hub-digital",
+        categoryId,
+      });
+    });
+
+    it("generates a unique slug when the name is already taken", async () => {
+      await db.insert(publishers).values({
+        userId: currentUserId,
+        bio: "Building things",
+        profileResponse: "founder",
+        objectiveResponse: "launch-product",
+        locationResponse: "CV1",
+        foundUsByResponse: "social-media",
+      });
+
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const first = await server.inject({
+        method: "POST",
+        url: "/v1/projects",
+        payload: { ...validProjectPayload, categoryId },
+      });
+      expect(first.statusCode).toBe(201);
+      expect(first.json().data.slug).toBe("hub-digital");
+
+      const second = await server.inject({
+        method: "POST",
+        url: "/v1/projects",
+        payload: { ...validProjectPayload, categoryId },
+      });
+      expect(second.statusCode).toBe(201);
+      expect(second.json().data.slug).not.toBe("hub-digital");
+      expect(second.json().data.slug).toMatch(/^hub-digital-/);
+    });
+
+    it("returns a validation error when the payload is invalid", async () => {
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/v1/projects",
+        payload: { ...validProjectPayload, categoryId, pricing: "invalid" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /v1/projects/mine", () => {
+    it("rejects the request when the user is unauthenticated", async () => {
+      getSessionMock.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/v1/projects/mine",
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("returns only the projects created by the current user's publisher", async () => {
+      const otherUserId = randomUUID();
+      await db.insert(users).values({
+        id: otherUserId,
+        name: "Other User",
+        email: `other-${otherUserId}@example.com`,
+        role: "user",
+      });
+
+      const [myPublisher] = await db
+        .insert(publishers)
+        .values({
+          userId: currentUserId,
+          bio: "Building things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV1",
+          foundUsByResponse: "social-media",
+        })
+        .returning({ id: publishers.id });
+
+      const [otherPublisher] = await db
+        .insert(publishers)
+        .values({
+          userId: otherUserId,
+          bio: "Building other things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV2",
+          foundUsByResponse: "friends",
+        })
+        .returning({ id: publishers.id });
+
+      await db.insert(projects).values([
+        {
+          publisherId: myPublisher.id,
+          categoryId,
+          slug: "meu-projeto",
+          name: "Meu Projeto",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        },
+        {
+          publisherId: otherPublisher.id,
+          categoryId,
+          slug: "projeto-alheio",
+          name: "Projeto Alheio",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        },
+      ]);
+
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/v1/projects/mine",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]).toMatchObject({
+        slug: "meu-projeto",
+        name: "Meu Projeto",
+      });
+      expect(body.meta.total).toBe(1);
+    });
+
+    it("returns 403 when the user has no publisher profile yet", async () => {
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/v1/projects/mine",
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe("PATCH /v1/projects/:id", () => {
+    it("rejects the request when the user is unauthenticated", async () => {
+      getSessionMock.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: "/v1/projects/1",
+        payload: { name: "New Name" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("updates a project owned by the current user's publisher", async () => {
+      const [publisher] = await db
+        .insert(publishers)
+        .values({
+          userId: currentUserId,
+          bio: "Building things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV1",
+          foundUsByResponse: "social-media",
+        })
+        .returning({ id: publishers.id });
+
+      const [project] = await db
+        .insert(projects)
+        .values({
+          publisherId: publisher.id,
+          categoryId,
+          slug: "meu-projeto",
+          name: "Meu Projeto",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        })
+        .returning({ id: projects.id });
+
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: `/v1/projects/${project.id}`,
+        payload: {
+          name: "Meu Projeto Atualizado",
+          pricing: "paid",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data.slug).toBe("meu-projeto");
+
+      const updated = await db.query.projects.findFirst({
+        where: eq(projects.id, project.id),
+      });
+
+      expect(updated).toMatchObject({
+        name: "Meu Projeto Atualizado",
+        pricing: "paid",
+        slug: "meu-projeto",
+      });
+    });
+
+    it("returns 404 when the project does not belong to the current user's publisher", async () => {
+      await db.insert(publishers).values({
+        userId: currentUserId,
+        bio: "Building things",
+        profileResponse: "founder",
+        objectiveResponse: "launch-product",
+        locationResponse: "CV1",
+        foundUsByResponse: "social-media",
+      });
+
+      const otherUserId = randomUUID();
+      await db.insert(users).values({
+        id: otherUserId,
+        name: "Other User",
+        email: `other-${otherUserId}@example.com`,
+        role: "user",
+      });
+
+      const [otherPublisher] = await db
+        .insert(publishers)
+        .values({
+          userId: otherUserId,
+          bio: "Building other things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV2",
+          foundUsByResponse: "friends",
+        })
+        .returning({ id: publishers.id });
+
+      const [otherProject] = await db
+        .insert(projects)
+        .values({
+          publisherId: otherPublisher.id,
+          categoryId,
+          slug: "projeto-alheio",
+          name: "Projeto Alheio",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        })
+        .returning({ id: projects.id });
+
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: `/v1/projects/${otherProject.id}`,
+        payload: { name: "Hijacked" },
+      });
+
+      expect(response.statusCode).toBe(404);
+
+      const untouched = await db.query.projects.findFirst({
+        where: eq(projects.id, otherProject.id),
+      });
+      expect(untouched?.name).toBe("Projeto Alheio");
+    });
+
+    it("returns 403 when the user has no publisher profile yet", async () => {
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "PATCH",
+        url: "/v1/projects/1",
+        payload: { name: "New Name" },
+      });
+
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe("GET /v1/projects", () => {
+    it("returns projects from all publishers without requiring authentication", async () => {
+      const otherUserId = randomUUID();
+      await db.insert(users).values({
+        id: otherUserId,
+        name: "Other User",
+        email: `other-${otherUserId}@example.com`,
+        role: "user",
+      });
+
+      const [myPublisher] = await db
+        .insert(publishers)
+        .values({
+          userId: currentUserId,
+          bio: "Building things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV1",
+          foundUsByResponse: "social-media",
+        })
+        .returning({ id: publishers.id });
+
+      const [otherPublisher] = await db
+        .insert(publishers)
+        .values({
+          userId: otherUserId,
+          bio: "Building other things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV2",
+          foundUsByResponse: "friends",
+        })
+        .returning({ id: publishers.id });
+
+      await db.insert(projects).values([
+        {
+          publisherId: myPublisher.id,
+          categoryId,
+          slug: "meu-projeto",
+          name: "Meu Projeto",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        },
+        {
+          publisherId: otherPublisher.id,
+          categoryId,
+          slug: "projeto-alheio",
+          name: "Projeto Alheio",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        },
+      ]);
+
+      getSessionMock.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/v1/projects",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data).toHaveLength(2);
+      expect(body.meta.total).toBe(2);
+      expect(body.data.map((p: { slug: string }) => p.slug).sort()).toEqual([
+        "meu-projeto",
+        "projeto-alheio",
+      ]);
+      expect(body.data[0].category).toMatchObject({ id: categoryId });
+    });
+
+    it("returns an empty list when there are no projects", async () => {
+      getSessionMock.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/v1/projects",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data).toEqual([]);
+      expect(body.meta.total).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Third in the series (after #33 and #34, both merged). The backend contract for the submit-project flow.

- Adds create/update/list-mine/list-all project endpoints under `/v1/projects` and a category listing under `/v1/categories`, registered on the Fastify server.
- Project creation and updates require a publisher profile via a new `requirePublisher` preHandler, which 403s with a dedicated error when the authenticated user hasn't onboarded as a publisher yet.
- Slugs are generated from the project name (`slugify`) and retried with a random suffix on unique-constraint collision.
- `PATCH /v1/projects/:id` scopes updates to the current user's own publisher (ownership check via `WHERE id = ? AND publisher_id = ?`).
- `GET /v1/projects` and `GET /v1/projects/mine` return paginated results with the category joined in.

## Test plan

- [x] `pnpm api:build`
- [x] `pnpm --filter @hubdigital/api test` — 17/17 passing, including 14 new e2e tests covering unauthenticated rejection, publisher-gating, ownership on update, and the public listing endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)