### PR TITLE
feat: wire submit-project form to the API

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "pnpm --filter @hubdigital/shared build && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/web/src/components/image-selector/image-selector.tsx
+++ b/web/src/components/image-selector/image-selector.tsx
@@ -18,12 +18,14 @@ type ImageSelectorProps = {
   label: string;
   recomandations?: string;
   actionLabel?: string;
+  required?: boolean;
 };
 
 export function ImageSelector({
   label,
   recomandations,
   actionLabel = " Carregar imagem",
+  required = false,
 }: ImageSelectorProps) {
   const [file, setFile] = useState<File | null>(null);
   const bannerPreview = useImagePreview(file);
@@ -37,7 +39,7 @@ export function ImageSelector({
   return (
     <Stack gap={"xxs"} align="flex-start" w={"100%"}>
       <Flex align={"center"} justify={"space-between"} w={"100%"}>
-        <Input.Wrapper label={label} withAsterisk></Input.Wrapper>
+        <Input.Wrapper label={label} withAsterisk={required}></Input.Wrapper>
         <Text c={"dimmed"} size="sm">
           {recomandations}
         </Text>

--- a/web/src/components/project-icon/project-icon.tsx
+++ b/web/src/components/project-icon/project-icon.tsx
@@ -1,0 +1,20 @@
+import { Avatar } from "@mantine/core";
+import { IconRocket } from "@tabler/icons-react";
+
+type ProjectIconProps = {
+  iconUrl?: string;
+  className?: string;
+  size?: number;
+};
+
+export function ProjectIcon({ iconUrl, className, size }: ProjectIconProps) {
+  if (iconUrl) {
+    return <img src={iconUrl} className={className}></img>;
+  }
+
+  return (
+    <Avatar size={size} radius={"lg"} className={className}>
+      <IconRocket size={28} />
+    </Avatar>
+  );
+}

--- a/web/src/lib/zod-error-map.ts
+++ b/web/src/lib/zod-error-map.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+const ptErrorMap: z.ZodErrorMap = (issue, ctx) => {
+  switch (issue.code) {
+    case z.ZodIssueCode.invalid_type:
+      if (issue.received === "undefined" || issue.received === "null") {
+        return { message: "Este campo é obrigatório" };
+      }
+      return { message: "Valor inválido" };
+    case z.ZodIssueCode.too_small:
+      if (issue.type === "string") {
+        return {
+          message: `Deve ter pelo menos ${issue.minimum} caracteres`,
+        };
+      }
+      if (issue.type === "array") {
+        return {
+          message: `Selecione pelo menos ${issue.minimum} opção(ões)`,
+        };
+      }
+      return { message: `Deve ser maior ou igual a ${issue.minimum}` };
+    case z.ZodIssueCode.too_big:
+      if (issue.type === "string") {
+        return { message: `Deve ter no máximo ${issue.maximum} caracteres` };
+      }
+      return { message: `Deve ser menor ou igual a ${issue.maximum}` };
+    case z.ZodIssueCode.invalid_string:
+      if (issue.validation === "url") {
+        return { message: "Informe um URL válido" };
+      }
+      return { message: "Formato inválido" };
+    case z.ZodIssueCode.invalid_enum_value:
+      return { message: "Selecione uma opção válida" };
+    default:
+      return { message: ctx.defaultError };
+  }
+};
+
+z.setErrorMap(ptErrorMap);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,5 @@
+import '@/lib/zod-error-map';
+
 import App from '@/app'
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/web/src/modules/submit/context/sumbmit-form.tsx
+++ b/web/src/modules/submit/context/sumbmit-form.tsx
@@ -1,32 +1,127 @@
+import { useForm, UseFormReturnType } from "@mantine/form";
 import { useCounter } from "@mantine/hooks";
+import { zodResolver } from "mantine-form-zod-resolver";
 import { createContext, PropsWithChildren } from "react";
 
 import { useNavigate } from "@tanstack/react-router";
+import {
+  createProjectSchema,
+  toCreateProjectPayload,
+  useCreateProject,
+} from "../hooks/use-create-project";
+import { CreateProjectInput } from "../types/project";
+
+const stepFieldNames: (keyof CreateProjectInput)[][] = [
+  ["name", "shortDescription", "websiteUrl"],
+  [
+    "projectStage",
+    "platform",
+    "audienceStage",
+    "businessModel",
+    "access",
+    "categoryId",
+    "pricing",
+  ],
+];
+
+const stepValidatedFieldNames: (keyof CreateProjectInput)[][] = [
+  [...stepFieldNames[0], "githubUrl", "description"],
+  stepFieldNames[1],
+];
 
 type SumbmitContextType = {
+  form: UseFormReturnType<CreateProjectInput>;
   active: number;
   isFist: boolean;
   isLast: boolean;
   next: () => void;
   previous: () => void;
+  submit: () => void;
+  canProceed: boolean;
+  isPending: boolean;
 };
 
 export const SumbmitContext = createContext<SumbmitContextType | undefined>(
   undefined
 );
 
+const initialValues: CreateProjectInput = {
+  name: "",
+  shortDescription: "",
+  description: "",
+  websiteUrl: "",
+  githubUrl: "",
+  pricing: "",
+  platform: [],
+  businessModel: "",
+  access: "",
+  projectStage: "",
+  audienceStage: "",
+  categoryId: "",
+};
+
 function SumbmitProvider({ children }: PropsWithChildren) {
   const min = 0;
-  const max = 4;
+  const max = 2;
   const [step, handlers] = useCounter(0, { min, max });
   const navigate = useNavigate();
 
+  const { createProject, isPending } = useCreateProject({
+    successMessage: "Projeto publicado com sucesso!",
+    errorMessage: "Não foi possível publicar o projeto",
+    onSuccess: () => {
+      navigate({ to: "/dashboard/releases" });
+    },
+  });
+
+  const form = useForm<CreateProjectInput>({
+    initialValues,
+    validate: zodResolver(createProjectSchema),
+  });
+
+  const currentStepFields = stepFieldNames[step] ?? [];
+  const currentStepValidatedFields =
+    stepValidatedFieldNames[step] ?? currentStepFields;
+  const canProceed = currentStepFields.every((field) => {
+    const value = form.values[field];
+    if (Array.isArray(value)) return value.length > 0;
+    return value !== "" && value !== undefined && value !== null;
+  });
+
+  function next() {
+    if (!canProceed) return;
+
+    const result = form.validate();
+
+    (Object.keys(initialValues) as (keyof CreateProjectInput)[])
+      .filter((field) => !currentStepValidatedFields.includes(field))
+      .forEach((field) => form.clearFieldError(field));
+
+    const stepHasErrors = currentStepValidatedFields.some(
+      (field) => result.errors[field]
+    );
+    if (stepHasErrors) return;
+
+    handlers.increment();
+  }
+
+  function submit() {
+    const result = form.validate();
+    if (result.hasErrors) return;
+
+    createProject(toCreateProjectPayload(form.values));
+  }
+
   const value = {
+    form,
     active: step,
     isFist: step === min,
     isLast: step === max,
-    next: handlers.increment,
+    next,
     previous: handlers.decrement,
+    submit,
+    canProceed,
+    isPending,
   };
 
   return (

--- a/web/src/modules/submit/hooks/use-categories.ts
+++ b/web/src/modules/submit/hooks/use-categories.ts
@@ -1,0 +1,16 @@
+import { API } from "@/api/api";
+import { useQuery } from "@tanstack/react-query";
+import { Category } from "../types/project";
+
+async function fetchCategories() {
+  const response = await API.get<{ data: Category[] }>("/categories");
+  return response.data.data;
+}
+
+export function useCategories() {
+  return useQuery({
+    queryKey: ["categories"],
+    queryFn: fetchCategories,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/web/src/modules/submit/hooks/use-create-project.ts
+++ b/web/src/modules/submit/hooks/use-create-project.ts
@@ -1,0 +1,98 @@
+import { API } from "@/api/api";
+import { CreateOptions, ItemResponse } from "@/types";
+import type { ProjectBody } from "@hubdigital/shared";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { z } from "zod";
+import {
+  accessValues,
+  audienceValues,
+  businessModelValues,
+  platformValues,
+  pricingValues,
+  projectStageValues,
+} from "../options";
+import { CreateProjectInput } from "../types/project";
+
+export const createProjectSchema = z.object({
+  name: z
+    .string()
+    .min(2, "Informe o nome do projeto")
+    .max(120, "Nome muito longo"),
+  shortDescription: z
+    .string()
+    .min(10, "A descrição curta deve ter pelo menos 10 caracteres")
+    .max(200, "A descrição curta deve ter no máximo 200 caracteres"),
+  description: z.string().max(20000).optional(),
+  websiteUrl: z.string().url("Informe um website válido"),
+  githubUrl: z
+    .string()
+    .url("Informe um link válido")
+    .optional()
+    .or(z.literal("")),
+  pricing: z.enum(pricingValues, {
+    errorMap: () => ({ message: "Selecione o modelo de preço" }),
+  }),
+  platform: z
+    .array(z.enum(platformValues))
+    .min(1, "Selecione pelo menos uma plataforma"),
+  businessModel: z.enum(businessModelValues, {
+    errorMap: () => ({ message: "Selecione o modelo de negócio" }),
+  }),
+  access: z.enum(accessValues, {
+    errorMap: () => ({ message: "Selecione o tipo de acesso" }),
+  }),
+  projectStage: z.enum(projectStageValues, {
+    errorMap: () => ({ message: "Selecione a maturidade do projeto" }),
+  }),
+  audienceStage: z.enum(audienceValues, {
+    errorMap: () => ({ message: "Selecione o público-alvo" }),
+  }),
+  categoryId: z.number({
+    invalid_type_error: "Selecione uma categoria",
+  }),
+});
+
+export type CreateProjectPayload = ProjectBody;
+
+type CreateProjectResponse = { id: number; slug: string };
+
+export function toCreateProjectPayload(
+  values: CreateProjectInput
+): CreateProjectPayload {
+  const { categoryId, githubUrl, description, ...rest } = values;
+
+  return {
+    ...rest,
+    categoryId: Number(categoryId),
+    githubUrl: githubUrl || undefined,
+    description: description || undefined,
+  } as CreateProjectPayload;
+}
+
+async function postProject(payload: CreateProjectPayload) {
+  const response = await API.post<ItemResponse<CreateProjectResponse>>(
+    "/projects",
+    payload
+  );
+  return response.data;
+}
+
+export function useCreateProject(options?: CreateOptions) {
+  const { mutate, isPending } = useMutation<
+    ItemResponse<CreateProjectResponse>,
+    AxiosError<{ error: { message: string } }>,
+    CreateProjectPayload
+  >({
+    mutationFn: postProject,
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+    meta: {
+      errorMessage: options?.errorMessage ?? "Erro ao publicar o projeto",
+      successMessage: options?.successMessage,
+      invalidatesQuery: ["my-projects"],
+    },
+  });
+
+  return { createProject: mutate, schema: createProjectSchema, isPending };
+}

--- a/web/src/modules/submit/hooks/use-create-project.ts
+++ b/web/src/modules/submit/hooks/use-create-project.ts
@@ -1,56 +1,25 @@
 import { API } from "@/api/api";
 import { CreateOptions, ItemResponse } from "@/types";
-import type { ProjectBody } from "@hubdigital/shared";
+import { projectBodySchema, type ProjectBody } from "@hubdigital/shared";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { z } from "zod";
-import {
-  accessValues,
-  audienceValues,
-  businessModelValues,
-  platformValues,
-  pricingValues,
-  projectStageValues,
-} from "../options";
 import { CreateProjectInput } from "../types/project";
 
-export const createProjectSchema = z.object({
-  name: z
-    .string()
-    .min(2, "Informe o nome do projeto")
-    .max(120, "Nome muito longo"),
-  shortDescription: z
-    .string()
-    .min(10, "A descrição curta deve ter pelo menos 10 caracteres")
-    .max(200, "A descrição curta deve ter no máximo 200 caracteres"),
-  description: z.string().max(20000).optional(),
-  websiteUrl: z.string().url("Informe um website válido"),
+// Reuses the shared API contract schema so field rules (lengths, enum
+// values, required-ness) can't drift between web and api. Only the two
+// fields where the Mantine form's raw values diverge from the wire
+// payload shape are overridden.
+export const createProjectSchema = projectBodySchema.extend({
   githubUrl: z
     .string()
     .url("Informe um link válido")
     .optional()
     .or(z.literal("")),
-  pricing: z.enum(pricingValues, {
-    errorMap: () => ({ message: "Selecione o modelo de preço" }),
-  }),
-  platform: z
-    .array(z.enum(platformValues))
-    .min(1, "Selecione pelo menos uma plataforma"),
-  businessModel: z.enum(businessModelValues, {
-    errorMap: () => ({ message: "Selecione o modelo de negócio" }),
-  }),
-  access: z.enum(accessValues, {
-    errorMap: () => ({ message: "Selecione o tipo de acesso" }),
-  }),
-  projectStage: z.enum(projectStageValues, {
-    errorMap: () => ({ message: "Selecione a maturidade do projeto" }),
-  }),
-  audienceStage: z.enum(audienceValues, {
-    errorMap: () => ({ message: "Selecione o público-alvo" }),
-  }),
-  categoryId: z.number({
-    invalid_type_error: "Selecione uma categoria",
-  }),
+  categoryId: z
+    .number({ invalid_type_error: "Selecione uma categoria" })
+    .int()
+    .positive(),
 });
 
 export type CreateProjectPayload = ProjectBody;

--- a/web/src/modules/submit/options.ts
+++ b/web/src/modules/submit/options.ts
@@ -1,0 +1,84 @@
+import {
+  accessValues,
+  audienceValues,
+  businessModelValues,
+  platformValues,
+  pricingValues,
+  projectStageValues,
+} from "@hubdigital/shared";
+
+export {
+  accessValues,
+  audienceValues,
+  businessModelValues,
+  platformValues,
+  pricingValues,
+  projectStageValues,
+};
+
+export const pricingLabels: Record<(typeof pricingValues)[number], string> = {
+  free: "Gratuito",
+  freemium: "Freemium",
+  paid: "Pago",
+};
+
+export const platformLabels: Record<(typeof platformValues)[number], string> = {
+  web: "Web",
+  mobile: "Mobile",
+  desktop: "Desktop",
+  api: "API",
+  other: "Outro",
+};
+
+export const businessModelLabels: Record<
+  (typeof businessModelValues)[number],
+  string
+> = {
+  b2b: "B2B",
+  b2c: "B2C",
+  b2g: "B2G (Governo)",
+  c2c: "C2C",
+  nonprofit: "Sem fins lucrativos",
+};
+
+export const accessLabels: Record<(typeof accessValues)[number], string> = {
+  open_source: "Código aberto",
+  closed_source: "Código fechado",
+  private_beta: "Beta privado",
+  public_beta: "Beta público",
+};
+
+export const projectStageLabels: Record<
+  (typeof projectStageValues)[number],
+  string
+> = {
+  idea: "Ideia",
+  development: "Em desenvolvimento",
+  mvp: "MVP",
+  launched: "Lançado",
+  growth: "Em crescimento",
+  maintenance: "Manutenção",
+  archived: "Arquivado",
+};
+
+export const audienceLabels: Record<(typeof audienceValues)[number], string> = {
+  students: "Estudantes",
+  developers: "Desenvolvedores",
+  businesses: "Empresas",
+  government: "Governo",
+  general_public: "Público em geral",
+};
+
+function toSelectData<T extends string>(labels: Record<T, string>) {
+  return Object.entries(labels).map(([value, label]) => ({
+    value,
+    label: label as string,
+  }));
+}
+
+export const pricingOptions = toSelectData(pricingLabels);
+export const platformOptions = toSelectData(platformLabels);
+export const businessModelOptions = toSelectData(businessModelLabels);
+export const accessOptions = toSelectData(accessLabels);
+export const projectStageOptions = toSelectData(projectStageLabels);
+export const audienceOptions = toSelectData(audienceLabels);

--- a/web/src/modules/submit/types/project.ts
+++ b/web/src/modules/submit/types/project.ts
@@ -1,0 +1,34 @@
+import type {
+  CategorySummary,
+  Project as SharedProject,
+  ProjectMinimal as SharedProjectMinimal,
+} from "@hubdigital/shared";
+import {
+  accessValues,
+  audienceValues,
+  businessModelValues,
+  platformValues,
+  pricingValues,
+  projectStageValues,
+} from "../options";
+
+export type CreateProjectInput = {
+  name: string;
+  shortDescription: string;
+  description?: string;
+  websiteUrl: string;
+  githubUrl?: string;
+  pricing: (typeof pricingValues)[number] | "";
+  platform: (typeof platformValues)[number][];
+  businessModel: (typeof businessModelValues)[number] | "";
+  access: (typeof accessValues)[number] | "";
+  projectStage: (typeof projectStageValues)[number] | "";
+  audienceStage: (typeof audienceValues)[number] | "";
+  categoryId: number | "";
+};
+
+export type Category = CategorySummary;
+
+export type Project = SharedProject;
+
+export type ProjectMinimal = SharedProjectMinimal;

--- a/web/src/modules/submit/ui/components/description-editor/description-editor.tsx
+++ b/web/src/modules/submit/ui/components/description-editor/description-editor.tsx
@@ -3,11 +3,13 @@ import { IconTrash } from "@tabler/icons-react";
 import Placeholder from "@tiptap/extension-placeholder";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-const content = "";
 
-type DescriptionEditorProps = {};
+type DescriptionEditorProps = {
+  value?: string;
+  onChange?: (html: string) => void;
+};
 
-export function DescriptionEditor({}: DescriptionEditorProps) {
+export function DescriptionEditor({ value, onChange }: DescriptionEditorProps) {
   const editor = useEditor({
     shouldRerenderOnTransaction: true,
     extensions: [
@@ -15,7 +17,10 @@ export function DescriptionEditor({}: DescriptionEditorProps) {
       Link,
       Placeholder.configure({ placeholder: "Descreve em detalhes" }),
     ],
-    content,
+    content: value ?? "",
+    onUpdate: ({ editor }) => {
+      onChange?.(editor.isEmpty ? "" : editor.getHTML());
+    },
   });
 
   return (

--- a/web/src/modules/submit/ui/components/project-card/project-card.tsx
+++ b/web/src/modules/submit/ui/components/project-card/project-card.tsx
@@ -1,11 +1,13 @@
+import { ProjectIcon } from "@/components/project-icon/project-icon";
 import { Badge, Flex, Stack, Text } from "@mantine/core";
 import classes from "./project-card.module.css";
 
 type ProjectCardProps = {
-  iconUrl: string;
+  iconUrl?: string;
   websiteUrl: string;
   name: string;
   description: string;
+  badges?: string[];
 };
 
 export function ProjectCard({
@@ -13,10 +15,11 @@ export function ProjectCard({
   iconUrl,
   websiteUrl,
   description,
+  badges = [],
 }: ProjectCardProps) {
   return (
     <Flex gap={"xs"}>
-      <img src={iconUrl} className={classes.icon}></img>
+      <ProjectIcon iconUrl={iconUrl} className={classes.icon} size={70} />
       <Stack gap={"none"}>
         <Text
           className={classes.titleLink}
@@ -30,15 +33,11 @@ export function ProjectCard({
         </Text>
         <Text size="sm">{description}</Text>
         <Flex gap={"xs"} visibleFrom="xs">
-          <Badge variant="dot" size="sm">
-            SaaS
-          </Badge>
-          <Badge variant="dot" size="sm">
-            AI
-          </Badge>
-          <Badge variant="dot" size="sm">
-            B2B
-          </Badge>
+          {badges.map((badge) => (
+            <Badge key={badge} variant="dot" size="sm">
+              {badge}
+            </Badge>
+          ))}
         </Flex>
       </Stack>
     </Flex>

--- a/web/src/modules/submit/ui/components/step-layout/step-layout.tsx
+++ b/web/src/modules/submit/ui/components/step-layout/step-layout.tsx
@@ -3,24 +3,32 @@ import { PropsWithChildren } from "react";
 import { useSubmitForm } from "../../../hooks/use-submit-form";
 
 export function StepLayout({ children }: PropsWithChildren) {
-  const { isFist, isLast, next, previous } = useSubmitForm();
+  const { isFist, isLast, next, previous, canProceed, submit, isPending } =
+    useSubmitForm();
   return (
     <Stack mih={400} gap={"xs"} mt={"lg"}>
       {children}
       <Flex justify={"flex-end"} gap={"sm"} mt="auto">
         {!isFist && (
-          <Button onClick={previous} variant="default">
+          <Button onClick={previous} variant="default" disabled={isPending}>
             Voltar
           </Button>
         )}
         {!isLast && (
           <Tooltip
-            label="Selecione uma opção para continuar"
+            label="Preencha os campos obrigatórios para continuar"
             withArrow
-            disabled={true}
+            disabled={canProceed}
           >
-            <Button onClick={next}>Proximo</Button>
+            <Button onClick={next} disabled={!canProceed}>
+              Proximo
+            </Button>
           </Tooltip>
+        )}
+        {isLast && (
+          <Button onClick={submit} loading={isPending}>
+            Publicar Projeto
+          </Button>
         )}
       </Flex>
     </Stack>

--- a/web/src/modules/submit/ui/container/form-stepper/form-stepper.tsx
+++ b/web/src/modules/submit/ui/container/form-stepper/form-stepper.tsx
@@ -11,7 +11,7 @@ import classes from "./form-stepper.module.css";
 
 export function FormStepper() {
   const matches = useMediaQuery("(min-width: 48em)");
-  const { active } = useSubmitForm();
+  const { active, form } = useSubmitForm();
 
   return (
     <Flex className={classes.container}>
@@ -27,7 +27,7 @@ export function FormStepper() {
           description={"Descreve teu projeto"}
         >
           <StepLayout>
-            <ProjectForm />
+            <ProjectForm form={form} />
           </StepLayout>
         </Stepper.Step>
         <Stepper.Step
@@ -36,7 +36,7 @@ export function FormStepper() {
           description="Enquadre teu projeto"
         >
           <StepLayout>
-            <ProjectCategories />
+            <ProjectCategories form={form} />
           </StepLayout>
         </Stepper.Step>
         <Stepper.Step

--- a/web/src/modules/submit/ui/container/project-categories/project-categories.tsx
+++ b/web/src/modules/submit/ui/container/project-categories/project-categories.tsx
@@ -1,75 +1,88 @@
+import { UseFormReturnType } from "@mantine/form";
 import { MultiSelect, Select, SimpleGrid, Stack } from "@mantine/core";
+import { useCategories } from "../../../hooks/use-categories";
+import {
+  accessOptions,
+  audienceOptions,
+  businessModelOptions,
+  platformOptions,
+  pricingOptions,
+  projectStageOptions,
+} from "../../../options";
+import { CreateProjectInput } from "../../../types/project";
 
-type ProjectCategoriesProps = {};
+type ProjectCategoriesProps = {
+  form: UseFormReturnType<CreateProjectInput>;
+};
 
-export function ProjectCategories({}: ProjectCategoriesProps) {
+export function ProjectCategories({ form }: ProjectCategoriesProps) {
+  const { data: categories, isLoading: isLoadingCategories } =
+    useCategories();
+
+  const categoryOptions =
+    categories?.map((category) => ({
+      value: String(category.id),
+      label: category.name,
+    })) ?? [];
+
   return (
     <Stack>
       <SimpleGrid cols={{ base: 1, sm: 2 }}>
         <Select
           label="Maturidade do projeto"
           placeholder="Selecione a maturidade"
-          data={[
-            "Ideia",
-            "Prova de conceito",
-            "MVP",
-            "Em crescimento",
-            "Escalado",
-          ]}
+          data={projectStageOptions}
+          required
+          {...form.getInputProps("projectStage")}
         />
         <MultiSelect
           label="Plataformas suportadas"
           placeholder="Selecione plataformas"
-          data={["Web", "Mobile (iOS)", "Mobile (Android)", "Desktop", "IoT"]}
+          data={platformOptions}
+          required
+          {...form.getInputProps("platform")}
         />
-        <MultiSelect
+        <Select
           label="Público-alvo"
           placeholder="Selecione público-alvo"
-          data={[
-            "Consumidor final (B2C)",
-            "Empresas (B2B)",
-            "Desenvolvedores",
-            "Educacional",
-            "Governo",
-          ]}
+          data={audienceOptions}
+          required
+          {...form.getInputProps("audienceStage")}
         />
-        <MultiSelect
+        <Select
           label="Modelo de negócio"
           placeholder="Selecione modelo de negócio"
-          data={[
-            "Assinatura",
-            "Freemium",
-            "Compra única",
-            "Publicidade",
-            "Marketplace",
-          ]}
+          data={businessModelOptions}
+          required
+          {...form.getInputProps("businessModel")}
+        />
+        <Select
+          label="Acesso neste lançamento"
+          placeholder="Selecione tipo de acesso"
+          data={accessOptions}
+          required
+          {...form.getInputProps("access")}
+        />
+        <Select
+          label="Modelo de preço"
+          placeholder="Selecione o modelo de preço"
+          data={pricingOptions}
+          required
+          {...form.getInputProps("pricing")}
         />
       </SimpleGrid>
       <Select
-        label="Localização da sede"
-        placeholder="Selecione localização"
-        data={[
-          "Brasil",
-          "Portugal",
-          "Estados Unidos",
-          "Reino Unido",
-          "Alemanha",
-        ]}
-      />
-      <Select
-        label="Acesso neste lançamento"
-        placeholder="Selecione tipo de acesso"
-        data={[
-          "Aberto ao público",
-          "Beta fechado",
-          "Somente por convite",
-          "Somente interno",
-        ]}
-      />
-      <MultiSelect
-        label="Categorias"
-        placeholder="Selecione categorias"
-        data={[]}
+        label="Qual categoria melhor descreve o teu projeto?"
+        placeholder="Procura e escolhe a categoria que melhor descreve a tua ideia"
+        data={categoryOptions}
+        disabled={isLoadingCategories}
+        searchable
+        required
+        value={form.values.categoryId ? String(form.values.categoryId) : null}
+        onChange={(value) =>
+          form.setFieldValue("categoryId", value ? Number(value) : "")
+        }
+        error={form.errors.categoryId}
       />
     </Stack>
   );

--- a/web/src/modules/submit/ui/container/project-form/project-form.tsx
+++ b/web/src/modules/submit/ui/container/project-form/project-form.tsx
@@ -1,24 +1,46 @@
 import { ImageSelector } from "@/components/image-selector/image-selector";
-import { Stack, TextInput } from "@mantine/core";
+import { UseFormReturnType } from "@mantine/form";
+import { Stack, Text, TextInput } from "@mantine/core";
+import { CreateProjectInput } from "../../../types/project";
 import { DescriptionEditor } from "../../components/description-editor/description-editor";
 
-type ProjectFormProps = {};
+type ProjectFormProps = {
+  form: UseFormReturnType<CreateProjectInput>;
+};
 
-export function ProjectForm({}: ProjectFormProps) {
+export function ProjectForm({ form }: ProjectFormProps) {
   return (
     <Stack>
-      <TextInput label="Nome do projeto" placeholder="Meu Projeto" required />
+      <TextInput
+        label="Nome do projeto"
+        placeholder="Meu Projeto"
+        required
+        {...form.getInputProps("name")}
+      />
       <TextInput
         label="Pequena descrição"
         placeholder="Meu Projeto resolve esse problema com isso.."
         required
+        {...form.getInputProps("shortDescription")}
       />
       <TextInput
         label="Website"
         placeholder="https://hubdigital.cv/"
         required
+        {...form.getInputProps("websiteUrl")}
       />
-      <DescriptionEditor />
+      <TextInput
+        label="GitHub"
+        placeholder="https://github.com/organizacao/projeto"
+        {...form.getInputProps("githubUrl")}
+      />
+      <DescriptionEditor
+        value={form.values.description}
+        onChange={(html) => form.setFieldValue("description", html)}
+      />
+      <Text size="sm" c="dimmed">
+        O envio de logo e banner estará disponível em breve.
+      </Text>
       <ImageSelector
         label="Logo"
         recomandations="Recomendações"

--- a/web/src/modules/submit/ui/container/project-review/project-review.tsx
+++ b/web/src/modules/submit/ui/container/project-review/project-review.tsx
@@ -1,38 +1,87 @@
-import { SimpleGrid, Skeleton, Stack, Text } from "@mantine/core";
+import { Box, SimpleGrid, Stack, Text } from "@mantine/core";
+import { useSubmitForm } from "../../../hooks/use-submit-form";
+import { useCategories } from "../../../hooks/use-categories";
+import {
+  accessLabels,
+  audienceLabels,
+  businessModelLabels,
+  platformLabels,
+  pricingLabels,
+  projectStageLabels,
+} from "../../../options";
 import { CategoriesDisplay } from "../../components/categories-diplay/categories-display";
 import { ProjectCard } from "../../components/project-card/project-card";
 
-type ProjectReviewProps = {};
+export function ProjectReview() {
+  const { form } = useSubmitForm();
+  const { data: categories } = useCategories();
 
-export function ProjectReview({}: ProjectReviewProps) {
+  const category = categories?.find((c) => c.id === form.values.categoryId);
+
+  const badges = [
+    form.values.pricing && pricingLabels[form.values.pricing],
+    form.values.businessModel && businessModelLabels[form.values.businessModel],
+  ].filter(Boolean) as string[];
+
   return (
     <Stack>
-      <Skeleton h={250} w={"100%"} animate={false}></Skeleton>
       <ProjectCard
-        name="Nome do projeto"
-        description="Este texto tem 50 caracteres do ipsa. Lorem ipsum dolor sit"
-        websiteUrl="https://hubdigital.cv/"
-        iconUrl="https://notifika.cv/assets/Icon3D-CREwZX7D.webp"
+        name={form.values.name || "Nome do projeto"}
+        description={
+          form.values.shortDescription || "Pequena descrição do projeto"
+        }
+        websiteUrl={form.values.websiteUrl || "#"}
+        badges={badges}
       />
       <SimpleGrid cols={{ base: 2, sm: 3 }} w={"100%"}>
-        <CategoriesDisplay label="Maturidade do projeto" badges={["Ideia"]} />
-        <CategoriesDisplay label="Plataformas suportadas" badges={["Web"]} />
-        <CategoriesDisplay label="Plataformas suportadas" badges={["Web"]} />
-        
+        <CategoriesDisplay
+          label="Categoria"
+          badges={category ? [category.name] : []}
+        />
+        <CategoriesDisplay
+          label="Maturidade do projeto"
+          badges={
+            form.values.projectStage
+              ? [projectStageLabels[form.values.projectStage]]
+              : []
+          }
+        />
+        <CategoriesDisplay
+          label="Plataformas suportadas"
+          badges={form.values.platform.map((p) => platformLabels[p])}
+        />
+        <CategoriesDisplay
+          label="Público-alvo"
+          badges={
+            form.values.audienceStage
+              ? [audienceLabels[form.values.audienceStage]]
+              : []
+          }
+        />
+        <CategoriesDisplay
+          label="Modelo de negócio"
+          badges={
+            form.values.businessModel
+              ? [businessModelLabels[form.values.businessModel]]
+              : []
+          }
+        />
+        <CategoriesDisplay
+          label="Acesso"
+          badges={
+            form.values.access ? [accessLabels[form.values.access]] : []
+          }
+        />
       </SimpleGrid>
 
-      <Text>
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Recusandae nam
-        sequi dicta? Ducimus ut eius accusantium. Obcaecati aperiam et quisquam
-        perferendis officia quos assumenda, pariatur, eveniet sunt nisi, nobis
-        alias. Lorem ipsum dolor sit amet consectetur adipisicing elit. A quas
-        adipisci doloremque non tenetur illum atque rem error molestias,
-        ducimus, amet reprehenderit praesentium id ad quia perferendis. Enim,
-        voluptatum molestias? Lorem ipsum dolor sit amet consectetur,
-        adipisicing elit. Atque ipsum veritatis reprehenderit recusandae ut
-        voluptatibus vitae quibusdam quisquam quis nesciunt quam voluptate
-        dolorum, doloremque et magni aliquam deleniti tempora dolor!
-      </Text>
+      {form.values.description && (
+        <Box
+          dangerouslySetInnerHTML={{ __html: form.values.description }}
+        />
+      )}
+      {!form.values.description && (
+        <Text c="dimmed">Nenhuma descrição detalhada foi adicionada.</Text>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary

Fourth in the series (after #33, #34, #35, all merged). Turns the existing submit stepper UI from placeholder into a real submission flow against the backend from #35.

- Replaces the submit stepper's placeholder state with real form data backed by `@mantine/form` and Zod validation (`createProjectSchema`), gated per step so users can't advance past required fields.
- Adds `useCreateProject` (`POST /v1/projects`, redirects to `/dashboard/releases` on success) and `useCategories` (`GET /v1/categories`) to back the category step with live data instead of hardcoded options.
- The review step now reflects actual entered values instead of static placeholders.
- Adds `ProjectIcon`, a small shared component used by both the submit and (in the next PR) public listing project cards.

## Test plan

- [x] `pnpm web:build`, verified with the not-yet-landed public listing/dashboard files set aside (isolated to just this PR's diff on top of `dev`)
- [x] Manual smoke test against a live API + Postgres: submit page renders with no console errors, categories load live from `GET /v1/categories` (21 real seeded categories), step 1 → step 2 navigation correctly gated by Zod validation, multi-select and searchable-select fields confirmed working individually. Did not complete a full end-to-end submission due to flaky click/focus timing in the remote browser automation on the densely-packed select grid — a tooling artifact, not a reproducible app issue (the same component types worked reliably when exercised individually). No stray test data was left in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)