### PR TITLE
fix: build shared package before api build

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "tsx --watch --env-file .env src/main.ts",
-    "build": "tsc && tsc-alias",
+    "build": "pnpm --filter @hubdigital/shared build && tsc && tsc-alias",
     "start": "node dist/main.js",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
## Summary

Small standalone hotfix, unrelated to the submit-form work in flight on #36.

While investigating #36's Cloudflare Pages CI failure (root cause: `packages/shared/dist` is gitignored, so a fresh checkout has nothing for `@hubdigital/shared` imports to resolve against until that package is built — fixed there for `web`), I found the API has the identical latent bug: `api/src/utils/constants.ts` has imported from `@hubdigital/shared` since #33, so `pnpm api:build` has been broken on a truly clean checkout since then. It just hasn't been caught because no CI currently runs `pnpm api:build`.

Same fix as #36: `api`'s own `build` script now builds `@hubdigital/shared` first.

## Test plan

- [x] Removed `packages/shared/dist` and confirmed `pnpm api:build` fails before this change, passes after
- [x] `pnpm --filter @hubdigital/api test` — 17/17 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)