### PR TITLE
feat: public project listing and release management

### DIFF
--- a/web/src/modules/project-list/components/project-card/project-card.tsx
+++ b/web/src/modules/project-list/components/project-card/project-card.tsx
@@ -1,3 +1,4 @@
+import { ProjectIcon } from "@/components/project-icon/project-icon";
 import {
   Anchor,
   Badge,
@@ -43,7 +44,7 @@ export function Projectcard({
   return (
     <Flex className={classes.card}>
       <Flex gap={"xs"}>
-        <img src={iconUrl} className={classes.icon}></img>
+        <ProjectIcon iconUrl={iconUrl} className={classes.icon} />
         <Stack gap={0}>
           <Anchor className={classes.titleLink} href={website} target="_blank">
             <Text className={classes.title}>{title}</Text>

--- a/web/src/modules/project-list/hooks/use-projects.ts
+++ b/web/src/modules/project-list/hooks/use-projects.ts
@@ -1,0 +1,18 @@
+import { API } from "@/api/api";
+import { ProjectMinimal } from "@/modules/submit/types/project";
+import { ListResponse } from "@/types";
+import { useQuery } from "@tanstack/react-query";
+
+async function fetchProjects() {
+  const response = await API.get<ListResponse<ProjectMinimal>>("/projects", {
+    params: { limit: 50 },
+  });
+  return response.data;
+}
+
+export function useProjects() {
+  return useQuery({
+    queryKey: ["projects"],
+    queryFn: fetchProjects,
+  });
+}

--- a/web/src/modules/project-list/index.tsx
+++ b/web/src/modules/project-list/index.tsx
@@ -1,50 +1,61 @@
-import calendarios from "@assets/calendarios.webp";
-import less from "@assets/less.webp";
-import nhafarmacia from "@assets/nhafarmacia.webp";
-import notifika from "@assets/notifika.webp";
-import { Button, Flex, Stack } from "@mantine/core";
+import { pricingLabels } from "@/modules/submit/options";
+import { ProjectMinimal } from "@/modules/submit/types/project";
+import { Stack, Text } from "@mantine/core";
+import { useProjects } from "./hooks/use-projects";
 import { Projectcard } from "./components/project-card/project-card";
 
+function toCardProps(project: ProjectMinimal) {
+  return {
+    id: project.id,
+    title: project.name,
+    description: project.shortDescription,
+    website: project.websiteUrl,
+    iconUrl: project.logoUrl ?? undefined,
+    topis: [project.category?.name, pricingLabels[project.pricing]].filter(
+      Boolean
+    ) as string[],
+    upCount: 0,
+  };
+}
+
 export function ProjectList() {
+  const { data, isLoading, isError } = useProjects();
+
+  if (isLoading) {
+    return (
+      <Stack gap={40}>
+        <Projectcard.Loading />
+        <Projectcard.Loading />
+        <Projectcard.Loading />
+      </Stack>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Stack align="center" py="xl">
+        <Text c="dimmed">
+          Não foi possível carregar os projetos. Tenta novamente mais tarde.
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (!data || data.data.length === 0) {
+    return (
+      <Stack align="center" py="xl">
+        <Text c="dimmed">
+          Ainda não há projetos publicados. Sê o primeiro a partilhar o teu!
+        </Text>
+      </Stack>
+    );
+  }
+
   return (
     <Stack gap={40}>
-      <Projectcard
-        title="Notifika"
-        id={1}
-        description="Conectamos empresas a clientes, tornando a comunicação direta mais eficiente em tempo real."
-        topis={["Comunicação", "SaaS", "B2B"]}
-        upCount={0}
-        iconUrl={notifika}
-        website="https://notifika.cv/"
-      />
-      <Projectcard
-        title="NhaFarma"
-        id={2}
-        description="Encontre farmácias de serviço em Cabo Verde, com praticidade e eficiência."
-        topis={["Informação", "SaaS", "B2C"]}
-        upCount={10}
-        iconUrl={nhafarmacia}
-        website="https://www.nhafarma.cv/"
-      />
-      <Projectcard
-        title="Calendario.cv"
-        id={3}
-        description="Encontre farmácias de serviço em Cabo Verde, com praticidade e eficiência."
-        topis={["Informação", "SaaS", "B2C"]}
-        upCount={100}
-        iconUrl={calendarios}
-        website="https://www.calendario.cv/"
-      />
-      <Projectcard
-        title="Chuva Less"
-        id={4}
-        description="O Less automatiza a criação, o gerenciamento e a implantação de sua infraestrutura de nuvem"
-        topis={["Serviço", "Cloud", "B2B"]}
-        upCount={1000}
-        iconUrl={less}
-        website="https://less.chuva.io/"
-      />
-      <Projectcard.Loading />
+      {data.data.map((project) => (
+        <Projectcard key={project.id} {...toCardProps(project)} />
+      ))}
     </Stack>
   );
 }

--- a/web/src/modules/project-list/types/project.ts
+++ b/web/src/modules/project-list/types/project.ts
@@ -1,6 +1,6 @@
 export type Project = {
   id: number;
-  iconUrl: string;
+  iconUrl?: string;
   website: string;
   title: string;
   description: string;

--- a/web/src/modules/releases/components/edit-project-modal/edit-project-modal.tsx
+++ b/web/src/modules/releases/components/edit-project-modal/edit-project-modal.tsx
@@ -1,0 +1,89 @@
+import {
+  createProjectSchema,
+  toCreateProjectPayload,
+} from "@/modules/submit/hooks/use-create-project";
+import { useUpdateProject } from "@/modules/submit/hooks/use-update-project";
+import { CreateProjectInput, Project } from "@/modules/submit/types/project";
+import { ProjectCategories } from "@/modules/submit/ui/container/project-categories/project-categories";
+import { ProjectForm } from "@/modules/submit/ui/container/project-form/project-form";
+import { Button, Divider, Flex, Modal, Stack } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { zodResolver } from "mantine-form-zod-resolver";
+
+type EditProjectModalProps = {
+  project: Project | null;
+  onClose: () => void;
+};
+
+function projectToFormValues(project: Project): CreateProjectInput {
+  return {
+    name: project.name,
+    shortDescription: project.shortDescription,
+    description: project.description ?? "",
+    websiteUrl: project.websiteUrl,
+    githubUrl: project.githubUrl ?? "",
+    pricing: project.pricing,
+    platform: project.platform,
+    businessModel: project.businessModel,
+    access: project.access,
+    projectStage: project.projectStage,
+    audienceStage: project.audienceStage,
+    categoryId: project.categoryId,
+  };
+}
+
+export function EditProjectModal({ project, onClose }: EditProjectModalProps) {
+  return (
+    <Modal
+      opened={!!project}
+      onClose={onClose}
+      title="Editar projeto"
+      size="lg"
+      centered
+    >
+      {project && <EditProjectForm project={project} onClose={onClose} />}
+    </Modal>
+  );
+}
+
+type EditProjectFormProps = {
+  project: Project;
+  onClose: () => void;
+};
+
+function EditProjectForm({ project, onClose }: EditProjectFormProps) {
+  const form = useForm<CreateProjectInput>({
+    initialValues: projectToFormValues(project),
+    validate: zodResolver(createProjectSchema),
+  });
+
+  const { updateProject, isPending } = useUpdateProject({
+    onSuccess: onClose,
+  });
+
+  function handleSubmit() {
+    const result = form.validate();
+    if (result.hasErrors) return;
+
+    updateProject({
+      id: project.id,
+      payload: toCreateProjectPayload(form.values),
+    });
+  }
+
+  return (
+    <Stack>
+      <ProjectForm form={form} />
+      <Divider label="Categoria" labelPosition="left" />
+      <ProjectCategories form={form} />
+      <Flex justify="flex-end" gap="sm" mt="md">
+        <Button variant="default" onClick={onClose} disabled={isPending}>
+          Cancelar
+        </Button>
+        <Button onClick={handleSubmit} loading={isPending}>
+          Guardar alterações
+        </Button>
+      </Flex>
+    </Stack>
+  );
+}

--- a/web/src/modules/releases/components/releases-item/releases-item.tsx
+++ b/web/src/modules/releases/components/releases-item/releases-item.tsx
@@ -1,6 +1,8 @@
+import { Project } from "@/modules/submit/types/project";
 import {
   ActionIcon,
   Avatar,
+  Badge,
   Flex,
   Paper,
   Stack,
@@ -9,32 +11,50 @@ import {
 } from "@mantine/core";
 import { IconLink, IconPencil, IconRocket } from "@tabler/icons-react";
 
-type ReleasesItemProps = {};
+type ReleasesItemProps = {
+  project: Project;
+  onEdit: (project: Project) => void;
+};
 
-export function ReleasesItem({}: ReleasesItemProps) {
+export function ReleasesItem({ project, onEdit }: ReleasesItemProps) {
   return (
     <Paper withBorder p="lg" radius="md">
       <Stack justify="space-between" h={"100%"}>
         <Stack gap={"xxs"}>
           <Flex>
-            <Avatar>
+            <Avatar src={project.logoUrl ?? undefined}>
               <IconRocket size={18} />
             </Avatar>
             <Flex w={"100%"} justify={"end"} gap={"xxs"}>
-              <ActionIcon variant="default" size={"lg"}>
+              <ActionIcon
+                component="a"
+                href={project.websiteUrl}
+                target="_blank"
+                variant="default"
+                size={"lg"}
+              >
                 <IconLink size={18} />
               </ActionIcon>
-              <ActionIcon variant="default" size={"lg"}>
+              <ActionIcon
+                variant="default"
+                size={"lg"}
+                onClick={() => onEdit(project)}
+              >
                 <IconPencil size={18} />
               </ActionIcon>
             </Flex>
           </Flex>
           <Title order={4} lineClamp={1}>
-            Notifika
+            {project.name}
           </Title>
           <Text size="sm" lineClamp={2} c={"dimmed"}>
-            Alguam descrição simpleficado sobre o que é o projeto e mais aalguma
+            {project.shortDescription}
           </Text>
+          {project.category && (
+            <Badge variant="light" size="sm" w={"fit-content"}>
+              {project.category.name}
+            </Badge>
+          )}
         </Stack>
       </Stack>
     </Paper>

--- a/web/src/modules/releases/components/releases-list/releases-list.tsx
+++ b/web/src/modules/releases/components/releases-list/releases-list.tsx
@@ -1,15 +1,62 @@
-import { SimpleGrid } from "@mantine/core";
+import { Project } from "@/modules/submit/types/project";
+import { Skeleton, SimpleGrid, Stack, Text } from "@mantine/core";
+import { useState } from "react";
+import { useMyProjects } from "../../hooks/use-my-projects";
+import { EditProjectModal } from "../edit-project-modal/edit-project-modal";
 import { ReleasesItem } from "../releases-item/releases-item";
 
-type ReleasesListProps = {};
+export function ReleasesList() {
+  const { data, isLoading, isError } = useMyProjects();
+  const [editingProject, setEditingProject] = useState<Project | null>(null);
 
-export function ReleasesList({}: ReleasesListProps) {
+  if (isLoading) {
+    return (
+      <SimpleGrid cols={{ base: 1, xl: 2 }} w={"100%"} spacing={"xs"}>
+        <Skeleton h={140} radius={"md"} />
+        <Skeleton h={140} radius={"md"} />
+      </SimpleGrid>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Stack align="center" py={"xl"}>
+        <Text c={"dimmed"}>
+          Não foi possível carregar os teus projetos. Tenta novamente mais
+          tarde.
+        </Text>
+      </Stack>
+    );
+  }
+
+  if (!data || data.data.length === 0) {
+    return (
+      <Stack align="center" py={"xl"}>
+        <Text c={"dimmed"}>Ainda não publicaste nenhum projeto.</Text>
+      </Stack>
+    );
+  }
+
   return (
-    <SimpleGrid cols={{ base: 1, xl: 2 }} w={"100%"} h={"100%"} spacing={"xs"}>
-      <ReleasesItem />
-      <ReleasesItem />
-      <ReleasesItem />
-      <ReleasesItem />
-    </SimpleGrid>
+    <>
+      <SimpleGrid
+        cols={{ base: 1, xl: 2 }}
+        w={"100%"}
+        h={"100%"}
+        spacing={"xs"}
+      >
+        {data.data.map((project) => (
+          <ReleasesItem
+            key={project.id}
+            project={project}
+            onEdit={setEditingProject}
+          />
+        ))}
+      </SimpleGrid>
+      <EditProjectModal
+        project={editingProject}
+        onClose={() => setEditingProject(null)}
+      />
+    </>
   );
 }

--- a/web/src/modules/releases/hooks/use-my-projects.ts
+++ b/web/src/modules/releases/hooks/use-my-projects.ts
@@ -1,0 +1,16 @@
+import { API } from "@/api/api";
+import { ListResponse } from "@/types";
+import { Project } from "@/modules/submit/types/project";
+import { useQuery } from "@tanstack/react-query";
+
+async function fetchMyProjects() {
+  const response = await API.get<ListResponse<Project>>("/projects/mine");
+  return response.data;
+}
+
+export function useMyProjects() {
+  return useQuery({
+    queryKey: ["my-projects"],
+    queryFn: fetchMyProjects,
+  });
+}

--- a/web/src/modules/submit/hooks/use-update-project.ts
+++ b/web/src/modules/submit/hooks/use-update-project.ts
@@ -1,0 +1,40 @@
+import { API } from "@/api/api";
+import { CreateOptions, ItemResponse } from "@/types";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { CreateProjectPayload } from "./use-create-project";
+
+type UpdateProjectResponse = { id: number; slug: string };
+
+type UpdateProjectVariables = {
+  id: number;
+  payload: Partial<CreateProjectPayload>;
+};
+
+async function patchProject({ id, payload }: UpdateProjectVariables) {
+  const response = await API.patch<ItemResponse<UpdateProjectResponse>>(
+    `/projects/${id}`,
+    payload
+  );
+  return response.data;
+}
+
+export function useUpdateProject(options?: CreateOptions) {
+  const { mutate, isPending } = useMutation<
+    ItemResponse<UpdateProjectResponse>,
+    AxiosError<{ error: { message: string } }>,
+    UpdateProjectVariables
+  >({
+    mutationFn: patchProject,
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+    meta: {
+      errorMessage: options?.errorMessage ?? "Erro ao atualizar o projeto",
+      successMessage:
+        options?.successMessage ?? "Projeto atualizado com sucesso!",
+      invalidatesQuery: ["my-projects"],
+    },
+  });
+
+  return { updateProject: mutate, isPending };
+}


### PR DESCRIPTION
## Summary

Fifth and final PR in the series (after #33–#37, all merged). Closes the MVP loop: sign in → onboard → submit project → project appears publicly → visitor opens project.

- Connects the landing page's project list to `GET /v1/projects` with loading, error, and empty states, replacing the hardcoded demo projects (Notifika, NhaFarma, Calendario.cv, Chuva Less).
- Mirrors the same pattern for the dashboard's releases view against `GET /v1/projects/mine`.
- Adds an edit flow: clicking a release's pencil icon opens a modal reusing the submit flow's `ProjectForm`/`ProjectCategories` and validation schema from #36, backed by a new `useUpdateProject` hook (`PATCH /v1/projects/:id`).

## Test plan

- [x] `pnpm web:build`, verified from a clean `packages/shared/dist` state (this is the last of the 5 PRs, so nothing left to set aside)
- [x] `pnpm --filter @hubdigital/api test` — 17/17 passing, including the `list-mine` and `update` endpoints this PR's UI calls
- [x] Manual smoke test: the public landing page renders real seeded projects with no console errors, confirmed against the live API
- [x] Could not interactively exercise the dashboard release-management/edit-modal flow in this session — the remote browser automation couldn't reliably reach `/dashboard/releases` (a pre-existing app-shell navigation quirk unrelated to this diff, not something introduced here). Verified instead via source-level review: the edit modal's data flow (`useMyProjects` → `EditProjectModal` → `useUpdateProject` → `PATCH /v1/projects/:id`) matches the already-tested API contract and reuses already-verified #36 form components exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)