### PR TITLE
feat: project upvotes and detail pages

### DIFF
--- a/api/src/db/migrations/0005_deep_toro.sql
+++ b/api/src/db/migrations/0005_deep_toro.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "project_upvotes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"project_id" integer NOT NULL,
+	"user_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "project_upvotes" ADD CONSTRAINT "project_upvotes_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_upvotes" ADD CONSTRAINT "project_upvotes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "project_upvotes_project_user_idx" ON "project_upvotes" USING btree ("project_id","user_id");

--- a/api/src/db/migrations/meta/0005_snapshot.json
+++ b/api/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,895 @@
+{
+  "id": "f304cfce-b096-4caf-bc6a-c09bb408d894",
+  "prevId": "7ff0c52e-cba0-4f1a-98c2-af0d9372c129",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_key_unique": {
+          "name": "categories_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_upvotes": {
+      "name": "project_upvotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_upvotes_project_user_idx": {
+          "name": "project_upvotes_project_user_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_upvotes_project_id_projects_id_fk": {
+          "name": "project_upvotes_project_id_projects_id_fk",
+          "tableFrom": "project_upvotes",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_upvotes_user_id_users_id_fk": {
+          "name": "project_upvotes_user_id_users_id_fk",
+          "tableFrom": "project_upvotes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publisher_id": {
+          "name": "publisher_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_image_url": {
+          "name": "banner_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "pricing",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "platform[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "businessModel": {
+          "name": "businessModel",
+          "type": "businessModel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access": {
+          "name": "access",
+          "type": "access",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectStage": {
+          "name": "projectStage",
+          "type": "projectStage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "audience",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_publisher_id_publishers_id_fk": {
+          "name": "projects_publisher_id_publishers_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "publishers",
+          "columnsFrom": [
+            "publisher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_category_id_categories_id_fk": {
+          "name": "projects_category_id_categories_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.publishers": {
+      "name": "publishers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_response": {
+          "name": "profile_response",
+          "type": "profile_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective_response": {
+          "name": "objective_response",
+          "type": "objective_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_response": {
+          "name": "location_response",
+          "type": "location_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "found_us_by_response": {
+          "name": "found_us_by_response",
+          "type": "found_us_by_responses",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "publisher_user_idx": {
+          "name": "publisher_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "publishers_user_id_users_id_fk": {
+          "name": "publishers_user_id_users_id_fk",
+          "tableFrom": "publishers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access": {
+      "name": "access",
+      "schema": "public",
+      "values": [
+        "open_source",
+        "closed_source",
+        "private_beta",
+        "public_beta"
+      ]
+    },
+    "public.audience": {
+      "name": "audience",
+      "schema": "public",
+      "values": [
+        "students",
+        "developers",
+        "businesses",
+        "government",
+        "general_public"
+      ]
+    },
+    "public.businessModel": {
+      "name": "businessModel",
+      "schema": "public",
+      "values": [
+        "b2b",
+        "b2c",
+        "b2g",
+        "c2c",
+        "nonprofit"
+      ]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": [
+        "web",
+        "mobile",
+        "desktop",
+        "api",
+        "other"
+      ]
+    },
+    "public.pricing": {
+      "name": "pricing",
+      "schema": "public",
+      "values": [
+        "free",
+        "freemium",
+        "paid"
+      ]
+    },
+    "public.projectStage": {
+      "name": "projectStage",
+      "schema": "public",
+      "values": [
+        "idea",
+        "development",
+        "mvp",
+        "launched",
+        "growth",
+        "maintenance",
+        "archived"
+      ]
+    },
+    "public.found_us_by_responses": {
+      "name": "found_us_by_responses",
+      "schema": "public",
+      "values": [
+        "social-media",
+        "friends",
+        "event",
+        "online-search"
+      ]
+    },
+    "public.location_responses": {
+      "name": "location_responses",
+      "schema": "public",
+      "values": [
+        "CV1",
+        "CV2",
+        "CV3",
+        "CV4",
+        "CV5",
+        "CV6",
+        "CV7",
+        "CV8",
+        "CV9",
+        "diaspora"
+      ]
+    },
+    "public.objective_responses": {
+      "name": "objective_responses",
+      "schema": "public",
+      "values": [
+        "discover-products",
+        "launch-product",
+        "networking",
+        "explore"
+      ]
+    },
+    "public.profile_responses": {
+      "name": "profile_responses",
+      "schema": "public",
+      "values": [
+        "student",
+        "technology-professional",
+        "founder",
+        "investor"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/db/migrations/meta/_journal.json
+++ b/api/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786803764907,
       "tag": "0004_mushy_manta",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1786847725100,
+      "tag": "0005_deep_toro",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/db/schemas/index.ts
+++ b/api/src/db/schemas/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth";
 export * from "./categories";
+export * from "./project-upvotes";
 export * from "./projects";
 export * from "./publishers";
 export * from "./relations";

--- a/api/src/db/schemas/project-upvotes.ts
+++ b/api/src/db/schemas/project-upvotes.ts
@@ -1,0 +1,24 @@
+import { integer, pgTable, serial, text, uniqueIndex } from "drizzle-orm/pg-core";
+import { users } from "./auth";
+import { projects } from "./projects";
+import { timestamps } from "./timestamps";
+
+export const projectUpvotes = pgTable(
+  "project_upvotes",
+  {
+    id: serial("id").primaryKey(),
+    projectId: integer("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    ...timestamps,
+  },
+  (table) => [
+    uniqueIndex("project_upvotes_project_user_idx").on(
+      table.projectId,
+      table.userId
+    ),
+  ]
+);

--- a/api/src/db/schemas/relations.ts
+++ b/api/src/db/schemas/relations.ts
@@ -1,14 +1,16 @@
 import { relations } from "drizzle-orm";
 import { users } from "./auth";
 import { categories } from "./categories";
+import { projectUpvotes } from "./project-upvotes";
 import { projects } from "./projects";
 import { publishers } from "./publishers";
 
-export const userRelations = relations(users, ({ one }) => ({
+export const userRelations = relations(users, ({ one, many }) => ({
   publisher: one(publishers, {
     fields: [users.id],
     references: [publishers.userId],
   }),
+  upvotes: many(projectUpvotes),
 }));
 
 export const publisherRelations = relations(publishers, ({ one, many }) => ({
@@ -19,7 +21,7 @@ export const publisherRelations = relations(publishers, ({ one, many }) => ({
   projects: many(projects),
 }));
 
-export const projectRelations = relations(projects, ({ one }) => ({
+export const projectRelations = relations(projects, ({ one, many }) => ({
   category: one(categories, {
     fields: [projects.categoryId],
     references: [categories.id],
@@ -28,8 +30,20 @@ export const projectRelations = relations(projects, ({ one }) => ({
     fields: [projects.publisherId],
     references: [publishers.id],
   }),
+  upvotes: many(projectUpvotes),
 }));
 
 export const categoriesRelations = relations(categories, ({ many }) => ({
   projects: many(projects),
+}));
+
+export const projectUpvoteRelations = relations(projectUpvotes, ({ one }) => ({
+  project: one(projects, {
+    fields: [projectUpvotes.projectId],
+    references: [projects.id],
+  }),
+  user: one(users, {
+    fields: [projectUpvotes.userId],
+    references: [users.id],
+  }),
 }));

--- a/api/src/modules/projects/projects-controllers.ts
+++ b/api/src/modules/projects/projects-controllers.ts
@@ -2,10 +2,14 @@ import { NotFoundError } from "@/utils/custom-errors";
 import {
   CreateProjectReply,
   CreateProjectRequest,
+  GetProjectReply,
+  GetProjectRequest,
   ListMyProjectsReply,
   ListMyProjectsRequest,
   ListProjectsReply,
   ListProjectsRequest,
+  ToggleUpvoteReply,
+  ToggleUpvoteRequest,
   UpdateProjectReply,
   UpdateProjectRequest,
 } from "./projects-schemas";
@@ -58,7 +62,8 @@ async function listMyProjectsHandler(
   const { data, total } = await ProjectsService.listMyProjects(
     req.db,
     publisher.id,
-    req.query
+    req.query,
+    req.user?.id
   );
 
   return reply.status(200).send({
@@ -73,7 +78,8 @@ async function listProjectsHandler(
 ) {
   const { data, total } = await ProjectsService.listProjects(
     req.db,
-    req.query
+    req.query,
+    req.user?.id
   );
 
   return reply.status(200).send({
@@ -82,9 +88,49 @@ async function listProjectsHandler(
   });
 }
 
+async function getProjectHandler(
+  req: GetProjectRequest,
+  reply: GetProjectReply
+) {
+  const project = await ProjectsService.getProjectBySlug(
+    req.db,
+    req.params.slug,
+    req.user?.id
+  );
+
+  if (!project) {
+    throw new NotFoundError();
+  }
+
+  return reply.status(200).send({
+    data: project,
+  });
+}
+
+async function toggleUpvoteHandler(
+  req: ToggleUpvoteRequest,
+  reply: ToggleUpvoteReply
+) {
+  const result = await ProjectsService.toggleUpvote(
+    req.db,
+    req.params.id,
+    req.user!.id
+  );
+
+  if (!result) {
+    throw new NotFoundError();
+  }
+
+  return reply.status(200).send({
+    data: result,
+  });
+}
+
 export const projectsController = {
   createProjectHandler,
   updateProjectHandler,
   listMyProjectsHandler,
   listProjectsHandler,
+  getProjectHandler,
+  toggleUpvoteHandler,
 };

--- a/api/src/modules/projects/projects-routes.ts
+++ b/api/src/modules/projects/projects-routes.ts
@@ -1,10 +1,13 @@
+import { authenticate } from "@/hooks/autenticate";
 import { requirePublisher } from "@/hooks/require-publisher";
 import { FastifyInstance } from "fastify";
 import { projectsController } from "./projects-controllers";
 import {
   createProjectRouteSchema,
+  getProjectRouteSchema,
   listMyProjectsRouteSchema,
   listProjectsRouteSchema,
+  toggleUpvoteRouteSchema,
   updateProjectRouteSchema,
 } from "./projects-schemas";
 
@@ -30,5 +33,16 @@ export async function projectsRoutes(server: FastifyInstance) {
     schema: listMyProjectsRouteSchema,
     preHandler: requirePublisher,
     handler: projectsController.listMyProjectsHandler,
+  });
+
+  server.get("/:slug", {
+    schema: getProjectRouteSchema,
+    handler: projectsController.getProjectHandler,
+  });
+
+  server.post("/:id/upvote", {
+    schema: toggleUpvoteRouteSchema,
+    preHandler: authenticate,
+    handler: projectsController.toggleUpvoteHandler,
   });
 }

--- a/api/src/modules/projects/projects-schemas.ts
+++ b/api/src/modules/projects/projects-schemas.ts
@@ -108,3 +108,46 @@ type ListProjectsGeneric = {
 
 export type ListProjectsRequest = FastifyRequest<ListProjectsGeneric>;
 export type ListProjectsReply = FastifyReply<ListProjectsGeneric>;
+
+export const getProjectRouteSchema = {
+  tags: ["projects"],
+  params: z.object({
+    slug: z.string(),
+  }),
+  response: {
+    200: z.object({
+      data: projectSchema,
+    }),
+    ...routeErrorResponses,
+  },
+};
+
+type GetProjectGeneric = {
+  Params: z.infer<typeof getProjectRouteSchema.params>;
+};
+
+export type GetProjectRequest = FastifyRequest<GetProjectGeneric>;
+export type GetProjectReply = FastifyReply<GetProjectGeneric>;
+
+export const toggleUpvoteRouteSchema = {
+  tags: ["projects"],
+  params: z.object({
+    id: z.coerce.number().int().positive(),
+  }),
+  response: {
+    200: z.object({
+      data: z.object({
+        upvoted: z.boolean(),
+        upvoteCount: z.number(),
+      }),
+    }),
+    ...routeErrorResponses,
+  },
+};
+
+type ToggleUpvoteGeneric = {
+  Params: z.infer<typeof toggleUpvoteRouteSchema.params>;
+};
+
+export type ToggleUpvoteRequest = FastifyRequest<ToggleUpvoteGeneric>;
+export type ToggleUpvoteReply = FastifyReply<ToggleUpvoteGeneric>;

--- a/api/src/modules/projects/projects-services.ts
+++ b/api/src/modules/projects/projects-services.ts
@@ -1,5 +1,5 @@
 import { DB } from "@/db";
-import { publishers, projects } from "@/db/schemas";
+import { publishers, projects, projectUpvotes } from "@/db/schemas";
 import { PG_ERR_UNIQUE_VIOLATION } from "@/utils/constants";
 import { errorLogger } from "@/utils/error-logger";
 import { slugify } from "@/utils/slugify";
@@ -24,6 +24,19 @@ type CreateProjectInput = {
 };
 
 type UpdateProjectInput = Partial<Omit<CreateProjectInput, "publisherId">>;
+
+function withUpvotes<T extends { upvotes: { userId: string }[] }>(
+  project: T,
+  userId?: string
+) {
+  const { upvotes, ...rest } = project;
+
+  return {
+    ...rest,
+    upvoteCount: upvotes.length,
+    hasUpvoted: userId ? upvotes.some((upvote) => upvote.userId === userId) : false,
+  };
+}
 
 async function findPublisherByUserId(db: DB, userId: string) {
   return db.query.publishers.findFirst({
@@ -79,12 +92,13 @@ async function updateProject(
 async function listMyProjects(
   db: DB,
   publisherId: number,
-  { limit, offset }: { limit: number; offset: number }
+  { limit, offset }: { limit: number; offset: number },
+  userId?: string
 ) {
   const [data, [{ total }]] = await Promise.all([
     db.query.projects.findMany({
       where: eq(projects.publisherId, publisherId),
-      with: { category: true },
+      with: { category: true, upvotes: true },
       orderBy: desc(projects.createdAt),
       limit,
       offset,
@@ -95,16 +109,17 @@ async function listMyProjects(
       .where(eq(projects.publisherId, publisherId)),
   ]);
 
-  return { data, total };
+  return { data: data.map((project) => withUpvotes(project, userId)), total };
 }
 
 async function listProjects(
   db: DB,
-  { limit, offset }: { limit: number; offset: number }
+  { limit, offset }: { limit: number; offset: number },
+  userId?: string
 ) {
   const [data, [{ total }]] = await Promise.all([
     db.query.projects.findMany({
-      with: { category: true },
+      with: { category: true, upvotes: true },
       orderBy: desc(projects.createdAt),
       limit,
       offset,
@@ -112,7 +127,62 @@ async function listProjects(
     db.select({ total: count() }).from(projects),
   ]);
 
-  return { data, total };
+  return { data: data.map((project) => withUpvotes(project, userId)), total };
+}
+
+async function getProjectBySlug(db: DB, slug: string, userId?: string) {
+  const result = await db.query.projects.findFirst({
+    where: eq(projects.slug, slug),
+    with: {
+      category: true,
+      publisher: { with: { user: true } },
+      upvotes: true,
+    },
+  });
+
+  if (!result) return null;
+
+  const { publisher, ...project } = result;
+
+  return {
+    ...withUpvotes(project, userId),
+    author: publisher?.user
+      ? {
+          id: publisher.user.id,
+          name: publisher.user.name,
+          image: publisher.user.image,
+        }
+      : null,
+  };
+}
+
+async function toggleUpvote(db: DB, projectId: number, userId: string) {
+  const project = await db.query.projects.findFirst({
+    where: eq(projects.id, projectId),
+    columns: { id: true },
+  });
+
+  if (!project) return null;
+
+  const existing = await db.query.projectUpvotes.findFirst({
+    where: and(
+      eq(projectUpvotes.projectId, projectId),
+      eq(projectUpvotes.userId, userId)
+    ),
+  });
+
+  if (existing) {
+    await db.delete(projectUpvotes).where(eq(projectUpvotes.id, existing.id));
+  } else {
+    await db.insert(projectUpvotes).values({ projectId, userId });
+  }
+
+  const [{ upvoteCount }] = await db
+    .select({ upvoteCount: count() })
+    .from(projectUpvotes)
+    .where(eq(projectUpvotes.projectId, projectId));
+
+  return { upvoted: !existing, upvoteCount };
 }
 
 export const ProjectsService = {
@@ -127,4 +197,9 @@ export const ProjectsService = {
     "projectsService.listMyProjects"
   ),
   listProjects: errorLogger(listProjects, "projectsService.listProjects"),
+  getProjectBySlug: errorLogger(
+    getProjectBySlug,
+    "projectsService.getProjectBySlug"
+  ),
+  toggleUpvote: errorLogger(toggleUpvote, "projectsService.toggleUpvote"),
 };

--- a/api/tests/e2e/projects.test.ts
+++ b/api/tests/e2e/projects.test.ts
@@ -594,4 +594,128 @@ describe("Projects module (e2e)", () => {
       expect(body.meta.total).toBe(0);
     });
   });
+
+  describe("POST /v1/projects/:id/upvote", () => {
+    async function insertProject() {
+      const [publisher] = await db
+        .insert(publishers)
+        .values({
+          userId: currentUserId,
+          bio: "Building things",
+          profileResponse: "founder",
+          objectiveResponse: "launch-product",
+          locationResponse: "CV1",
+          foundUsByResponse: "social-media",
+        })
+        .returning({ id: publishers.id });
+
+      const [project] = await db
+        .insert(projects)
+        .values({
+          publisherId: publisher.id,
+          categoryId,
+          slug: "meu-projeto",
+          name: "Meu Projeto",
+          shortDescription: validProjectPayload.shortDescription,
+          websiteUrl: validProjectPayload.websiteUrl,
+          pricing: "free",
+          platform: ["web"],
+          businessModel: "b2c",
+          access: "public_beta",
+          projectStage: "mvp",
+          audienceStage: "general_public",
+        })
+        .returning({ id: projects.id });
+
+      return project;
+    }
+
+    it("rejects the request when the user is unauthenticated", async () => {
+      const project = await insertProject();
+      getSessionMock.mockResolvedValue(null);
+
+      const response = await server.inject({
+        method: "POST",
+        url: `/v1/projects/${project.id}/upvote`,
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("returns 404 when the project does not exist", async () => {
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/v1/projects/999999/upvote",
+      });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it("adds an upvote for the current user on first call", async () => {
+      const project = await insertProject();
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      const response = await server.inject({
+        method: "POST",
+        url: `/v1/projects/${project.id}/upvote`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data).toEqual({
+        upvoted: true,
+        upvoteCount: 1,
+      });
+    });
+
+    it("removes the upvote when called again by the same user", async () => {
+      const project = await insertProject();
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      await server.inject({
+        method: "POST",
+        url: `/v1/projects/${project.id}/upvote`,
+      });
+
+      const response = await server.inject({
+        method: "POST",
+        url: `/v1/projects/${project.id}/upvote`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json().data).toEqual({
+        upvoted: false,
+        upvoteCount: 0,
+      });
+    });
+
+    it("reflects the vote on the project detail endpoint", async () => {
+      const project = await insertProject();
+      getSessionMock.mockResolvedValue({
+        user: { id: currentUserId, role: "user" },
+      });
+
+      await server.inject({
+        method: "POST",
+        url: `/v1/projects/${project.id}/upvote`,
+      });
+
+      const response = await server.inject({
+        method: "GET",
+        url: "/v1/projects/meu-projeto",
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.data.upvoteCount).toBe(1);
+      expect(body.data.hasUpvoted).toBe(true);
+    });
+  });
 });

--- a/packages/shared/src/project-schema.ts
+++ b/packages/shared/src/project-schema.ts
@@ -14,6 +14,12 @@ export const categorySummarySchema = z.object({
   name: z.string(),
 });
 
+export const projectAuthorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  image: z.string().nullable(),
+});
+
 export const projectBodySchema = z.object({
   name: z.string().min(2).max(120),
   shortDescription: z.string().min(10).max(200),
@@ -48,6 +54,9 @@ export const projectSchema = z.object({
   audienceStage: z.enum(audienceValues),
   categoryId: z.number(),
   category: categorySummarySchema.nullable().optional(),
+  author: projectAuthorSchema.nullable().optional(),
+  upvoteCount: z.number(),
+  hasUpvoted: z.boolean(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -62,11 +71,14 @@ export const projectMinimalFields = {
   pricing: true,
   category: true,
   createdAt: true,
+  upvoteCount: true,
+  hasUpvoted: true,
 } as const;
 
 export const projectMinimalSchema = projectSchema.pick(projectMinimalFields);
 
 export type CategorySummary = z.infer<typeof categorySummarySchema>;
+export type ProjectAuthor = z.infer<typeof projectAuthorSchema>;
 export type ProjectBody = z.infer<typeof projectBodySchema>;
 export type Project = z.infer<typeof projectSchema>;
 export type ProjectMinimal = z.infer<typeof projectMinimalSchema>;

--- a/web/src/components/project-banner/project-banner.module.css
+++ b/web/src/components/project-banner/project-banner.module.css
@@ -1,0 +1,19 @@
+.banner {
+  position: relative;
+  width: 100%;
+  min-height: rem(220px);
+  border-radius: var(--mantine-radius-md);
+  overflow: hidden;
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.placeholder {
+  border: 1.5px dashed var(--mantine-color-default-border);
+  background-color: var(--mantine-color-default-hover);
+  color: var(--mantine-color-dimmed);
+}

--- a/web/src/components/project-banner/project-banner.tsx
+++ b/web/src/components/project-banner/project-banner.tsx
@@ -1,0 +1,33 @@
+import { Center, Stack, Text } from "@mantine/core";
+import { IconPhoto } from "@tabler/icons-react";
+import classes from "./project-banner.module.css";
+
+type ProjectBannerProps = {
+  bannerUrl?: string | null;
+  className?: string;
+};
+
+export function ProjectBanner({ bannerUrl, className }: ProjectBannerProps) {
+  const rootClassName = className
+    ? `${classes.banner} ${className}`
+    : classes.banner;
+
+  if (bannerUrl) {
+    return (
+      <div className={rootClassName}>
+        <img src={bannerUrl} alt="" className={classes.image} />
+      </div>
+    );
+  }
+
+  return (
+    <Center className={`${rootClassName} ${classes.placeholder}`}>
+      <Stack align="center" gap={4}>
+        <IconPhoto size={32} stroke={1.5} />
+        <Text size="xs" c="dimmed">
+          Imagem em breve
+        </Text>
+      </Stack>
+    </Center>
+  );
+}

--- a/web/src/modules/project-detail/components/project-author/project-author.tsx
+++ b/web/src/modules/project-detail/components/project-author/project-author.tsx
@@ -1,0 +1,40 @@
+import type { ProjectAuthor } from "@hubdigital/shared";
+import { Avatar, Group, Text } from "@mantine/core";
+
+type ProjectAuthorRowProps = {
+  author?: ProjectAuthor | null;
+  size?: number;
+};
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+}
+
+export function ProjectAuthorRow({ author, size = 28 }: ProjectAuthorRowProps) {
+  if (!author) {
+    return (
+      <Group gap="xs">
+        <Avatar size={size} radius="xl" />
+        <Text size="sm" c="dimmed">
+          Publicador desconhecido
+        </Text>
+      </Group>
+    );
+  }
+
+  return (
+    <Group gap="xs">
+      <Avatar src={author.image ?? undefined} size={size} radius="xl">
+        {getInitials(author.name)}
+      </Avatar>
+      <Text size="sm" fw={500}>
+        {author.name}
+      </Text>
+    </Group>
+  );
+}

--- a/web/src/modules/project-detail/components/project-detail-modal/project-detail-modal.module.css
+++ b/web/src/modules/project-detail/components/project-detail-modal/project-detail-modal.module.css
@@ -1,0 +1,8 @@
+.toolbar {
+  border-bottom: 1px solid var(--mantine-color-default-border);
+}
+
+.body {
+  max-height: calc(90vh - 52px);
+  overflow-y: auto;
+}

--- a/web/src/modules/project-detail/components/project-detail-modal/project-detail-modal.tsx
+++ b/web/src/modules/project-detail/components/project-detail-modal/project-detail-modal.tsx
@@ -1,0 +1,138 @@
+import { ProjectMinimal } from "@/modules/submit/types/project";
+import { ActionIcon, Group, Modal, Skeleton, Stack, Text } from "@mantine/core";
+import {
+  IconArrowsMaximize,
+  IconChevronLeft,
+  IconChevronRight,
+  IconX,
+} from "@tabler/icons-react";
+import { useNavigate } from "@tanstack/react-router";
+import { useProject } from "../../hooks/use-project";
+import { ProjectDetailView } from "../project-detail-view/project-detail-view";
+import classes from "./project-detail-modal.module.css";
+
+type ProjectDetailModalProps = {
+  projects: ProjectMinimal[];
+  index: number | null;
+  onIndexChange: (index: number) => void;
+  onClose: () => void;
+};
+
+export function ProjectDetailModal({
+  projects,
+  index,
+  onIndexChange,
+  onClose,
+}: ProjectDetailModalProps) {
+  const current = index !== null ? projects[index] : undefined;
+
+  return (
+    <Modal
+      opened={!!current}
+      onClose={onClose}
+      size="70rem"
+      padding={0}
+      withCloseButton={false}
+      radius="md"
+      centered
+    >
+      {current && index !== null && (
+        <ProjectDetailModalContent
+          slug={current.slug}
+          hasPrev={index > 0}
+          hasNext={index < projects.length - 1}
+          onPrev={() => onIndexChange(index - 1)}
+          onNext={() => onIndexChange(index + 1)}
+          onClose={onClose}
+        />
+      )}
+    </Modal>
+  );
+}
+
+type ProjectDetailModalContentProps = {
+  slug: string;
+  hasPrev: boolean;
+  hasNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+};
+
+function ProjectDetailModalContent({
+  slug,
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  onClose,
+}: ProjectDetailModalContentProps) {
+  const { data, isLoading, isError } = useProject(slug);
+  const navigate = useNavigate();
+
+  function handleExpand() {
+    onClose();
+    navigate({ to: "/projects/$slug", params: { slug } });
+  }
+
+  return (
+    <Stack gap={0}>
+      <Group
+        justify="space-between"
+        className={classes.toolbar}
+        px="md"
+        py="sm"
+      >
+        <Group gap={4}>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            onClick={handleExpand}
+            aria-label="Expandir projeto"
+          >
+            <IconArrowsMaximize size={18} />
+          </ActionIcon>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            onClick={onPrev}
+            disabled={!hasPrev}
+            aria-label="Projeto anterior"
+          >
+            <IconChevronLeft size={18} />
+          </ActionIcon>
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            onClick={onNext}
+            disabled={!hasNext}
+            aria-label="Próximo projeto"
+          >
+            <IconChevronRight size={18} />
+          </ActionIcon>
+        </Group>
+        <ActionIcon
+          variant="subtle"
+          color="gray"
+          onClick={onClose}
+          aria-label="Fechar"
+        >
+          <IconX size={18} />
+        </ActionIcon>
+      </Group>
+
+      <Stack className={classes.body} px="xl" pb="xl" pt="md">
+        {isLoading && (
+          <Stack gap="lg">
+            <Skeleton h={28} w={220} />
+            <Skeleton h={220} radius="md" />
+          </Stack>
+        )}
+        {isError && (
+          <Text c="dimmed">Não foi possível carregar este projeto.</Text>
+        )}
+        {data && <ProjectDetailView project={data} />}
+      </Stack>
+    </Stack>
+  );
+}

--- a/web/src/modules/project-detail/components/project-detail-view/project-detail-view.module.css
+++ b/web/src/modules/project-detail/components/project-detail-view/project-detail-view.module.css
@@ -1,0 +1,13 @@
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr);
+  gap: var(--mantine-spacing-xl);
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.banner {
+  height: 100%;
+}

--- a/web/src/modules/project-detail/components/project-detail-view/project-detail-view.tsx
+++ b/web/src/modules/project-detail/components/project-detail-view/project-detail-view.tsx
@@ -1,0 +1,117 @@
+import { ProjectBanner } from "@/components/project-banner/project-banner";
+import {
+  accessLabels,
+  audienceLabels,
+  businessModelLabels,
+  platformLabels,
+  pricingLabels,
+  projectStageLabels,
+} from "@/modules/submit/options";
+import { Project } from "@/modules/submit/types/project";
+import { CategoriesDisplay } from "@/modules/submit/ui/components/categories-diplay/categories-display";
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Flex,
+  Group,
+  SimpleGrid,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import {
+  IconBrandGithub,
+  IconExternalLink,
+} from "@tabler/icons-react";
+import { ProjectAuthorRow } from "../project-author/project-author";
+import classes from "./project-detail-view.module.css";
+
+type ProjectDetailViewProps = {
+  project: Project;
+};
+
+export function ProjectDetailView({ project }: ProjectDetailViewProps) {
+  const categoryBadges = project.category ? [project.category.name] : [];
+
+  return (
+    <Stack gap="lg">
+      <Flex justify="space-between" align="flex-start" wrap="wrap" gap="md">
+        <Stack gap={6}>
+          <Title order={2}>{project.name}</Title>
+          <ProjectAuthorRow author={project.author} />
+        </Stack>
+        <Group gap="xs">
+          {project.githubUrl && (
+            <ActionIcon
+              component="a"
+              href={project.githubUrl}
+              target="_blank"
+              rel="noreferrer"
+              variant="default"
+              size="lg"
+              aria-label="GitHub"
+            >
+              <IconBrandGithub size={18} />
+            </ActionIcon>
+          )}
+          <Button
+            component="a"
+            href={project.websiteUrl}
+            target="_blank"
+            rel="noreferrer"
+            rightSection={<IconExternalLink size={16} />}
+          >
+            Visitar site
+          </Button>
+        </Group>
+      </Flex>
+
+      <div className={classes.grid}>
+        <ProjectBanner bannerUrl={project.bannerImageUrl} className={classes.banner} />
+
+        <Stack gap="lg">
+          <Stack gap="xxs">
+            <Text fw={600}>Sobre o projeto</Text>
+            {project.description ? (
+              <Box dangerouslySetInnerHTML={{ __html: project.description }} />
+            ) : (
+              <Text c="dimmed">{project.shortDescription}</Text>
+            )}
+          </Stack>
+
+          <Stack gap="xxs">
+            <Text fw={600}>Mais</Text>
+            <SimpleGrid cols={{ base: 2, xs: 3 }} spacing="sm">
+              <CategoriesDisplay label="Categoria" badges={categoryBadges} />
+              <CategoriesDisplay
+                label="Preço"
+                badges={[pricingLabels[project.pricing]]}
+              />
+              <CategoriesDisplay
+                label="Maturidade"
+                badges={[projectStageLabels[project.projectStage]]}
+              />
+              <CategoriesDisplay
+                label="Público-alvo"
+                badges={[audienceLabels[project.audienceStage]]}
+              />
+              <CategoriesDisplay
+                label="Modelo de negócio"
+                badges={[businessModelLabels[project.businessModel]]}
+              />
+              <CategoriesDisplay
+                label="Acesso"
+                badges={[accessLabels[project.access]]}
+              />
+              <CategoriesDisplay
+                label="Plataformas"
+                badges={project.platform.map((p) => platformLabels[p])}
+              />
+            </SimpleGrid>
+          </Stack>
+        </Stack>
+      </div>
+    </Stack>
+  );
+}

--- a/web/src/modules/project-detail/hooks/use-project.ts
+++ b/web/src/modules/project-detail/hooks/use-project.ts
@@ -1,0 +1,17 @@
+import { API } from "@/api/api";
+import { Project } from "@/modules/submit/types/project";
+import { ItemResponse } from "@/types";
+import { useQuery } from "@tanstack/react-query";
+
+async function fetchProject(slug: string) {
+  const response = await API.get<ItemResponse<Project>>(`/projects/${slug}`);
+  return response.data.data;
+}
+
+export function useProject(slug: string | undefined) {
+  return useQuery({
+    queryKey: ["project", slug],
+    queryFn: () => fetchProject(slug as string),
+    enabled: Boolean(slug),
+  });
+}

--- a/web/src/modules/project-list/components/project-card/project-card.module.css
+++ b/web/src/modules/project-list/components/project-card/project-card.module.css
@@ -22,6 +22,10 @@
   text-decoration: none;
 }
 
+.clickable {
+  cursor: pointer;
+}
+
 .title {
   font-weight: bold;
   font-size: 500;

--- a/web/src/modules/project-list/components/project-card/project-card.tsx
+++ b/web/src/modules/project-list/components/project-card/project-card.tsx
@@ -13,9 +13,14 @@ import { IconConfetti } from "@tabler/icons-react";
 import classes from "./project-card.module.css";
 
 import { useMediaQuery } from "@mantine/hooks";
-import { useState } from "react";
 import { useReward } from "react-rewards";
 import { Project } from "../../types/project";
+
+type ProjectcardProps = Project & {
+  onOpen?: () => void;
+  onUpvote?: () => void;
+  isUpvotePending?: boolean;
+};
 
 export function Projectcard({
   id,
@@ -24,29 +29,44 @@ export function Projectcard({
   iconUrl,
   topis,
   upCount,
+  hasUpvoted,
   website,
-}: Project) {
+  onOpen,
+  onUpvote,
+  isUpvotePending,
+}: ProjectcardProps) {
   // Equivalent to $mantine-breakpoint-xs -> 36em
   const rewardId = "rewardId" + id.toString();
 
   const isRowButton = useMediaQuery("(min-width: 36em)");
-  const [up, setUp] = useState(upCount);
 
-  const { reward, isAnimating } = useReward(rewardId, "confetti", {
-    lifetime: 2000,
+  const { reward } = useReward(rewardId, "confetti", {
+    // lifetime is a frame count (at 60fps), not milliseconds — 120 ≈ 2s
+    lifetime: 120,
   });
 
   function onClickUp() {
-    setUp((prev) => prev + 1);
-    reward();
+    if (!hasUpvoted) reward();
+    onUpvote?.();
   }
 
   return (
     <Flex className={classes.card}>
-      <Flex gap={"xs"}>
+      <Flex
+        gap={"xs"}
+        className={onOpen ? classes.clickable : undefined}
+        onClick={onOpen}
+        role={onOpen ? "button" : undefined}
+        tabIndex={onOpen ? 0 : undefined}
+      >
         <ProjectIcon iconUrl={iconUrl} className={classes.icon} />
         <Stack gap={0}>
-          <Anchor className={classes.titleLink} href={website} target="_blank">
+          <Anchor
+            className={classes.titleLink}
+            href={website}
+            target="_blank"
+            onClick={(event) => event.stopPropagation()}
+          >
             <Text className={classes.title}>{title}</Text>
           </Anchor>
           <Text lh={"sm"} fz="xs">
@@ -66,7 +86,8 @@ export function Projectcard({
       {!isRowButton && <span id={rewardId} />}
 
       <Button
-        variant="default"
+        variant={hasUpvoted ? "light" : "default"}
+        color={hasUpvoted ? "orange" : undefined}
         className={classes.upvotetest}
         leftSection={isRowButton ? <span id={rewardId} /> : null}
         rightSection={<IconConfetti size={18} className={classes.upvoteIcon} />}
@@ -77,9 +98,9 @@ export function Projectcard({
           label: classes.label,
         }}
         onClick={onClickUp}
-        disabled={isAnimating}
+        disabled={isUpvotePending}
       >
-        <Text size="sm">{up}</Text>
+        <Text size="sm">{upCount}</Text>
       </Button>
     </Flex>
   );

--- a/web/src/modules/project-list/hooks/use-toggle-upvote.ts
+++ b/web/src/modules/project-list/hooks/use-toggle-upvote.ts
@@ -1,0 +1,65 @@
+import { API } from "@/api/api";
+import { ProjectMinimal } from "@/modules/submit/types/project";
+import { ItemResponse, ListResponse } from "@/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type ToggleUpvoteResponse = { upvoted: boolean; upvoteCount: number };
+
+async function toggleUpvote(projectId: number) {
+  const response = await API.post<ItemResponse<ToggleUpvoteResponse>>(
+    `/projects/${projectId}/upvote`
+  );
+  return response.data.data;
+}
+
+function patchProject(project: ProjectMinimal): ProjectMinimal {
+  return {
+    ...project,
+    hasUpvoted: !project.hasUpvoted,
+    upvoteCount: project.hasUpvoted
+      ? project.upvoteCount - 1
+      : project.upvoteCount + 1,
+  };
+}
+
+export function useToggleUpvote() {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, variables } = useMutation({
+    mutationFn: toggleUpvote,
+    onMutate: async (projectId: number) => {
+      await queryClient.cancelQueries({ queryKey: ["projects"] });
+
+      const previous = queryClient.getQueryData<ListResponse<ProjectMinimal>>(
+        ["projects"]
+      );
+
+      queryClient.setQueryData<ListResponse<ProjectMinimal>>(
+        ["projects"],
+        (current) =>
+          current && {
+            ...current,
+            data: current.data.map((project) =>
+              project.id === projectId ? patchProject(project) : project
+            ),
+          }
+      );
+
+      return { previous };
+    },
+    onError: (_error, _projectId, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["projects"], context.previous);
+      }
+    },
+    meta: {
+      errorMessage: "Erro ao votar no projeto",
+    },
+  });
+
+  return {
+    toggleUpvote: mutate,
+    isPending,
+    pendingProjectId: isPending ? variables : undefined,
+  };
+}

--- a/web/src/modules/project-list/index.tsx
+++ b/web/src/modules/project-list/index.tsx
@@ -1,12 +1,16 @@
+import { ProjectDetailModal } from "@/modules/project-detail/components/project-detail-modal/project-detail-modal";
 import { pricingLabels } from "@/modules/submit/options";
 import { ProjectMinimal } from "@/modules/submit/types/project";
 import { Stack, Text } from "@mantine/core";
+import { useState } from "react";
 import { useProjects } from "./hooks/use-projects";
+import { useToggleUpvote } from "./hooks/use-toggle-upvote";
 import { Projectcard } from "./components/project-card/project-card";
 
 function toCardProps(project: ProjectMinimal) {
   return {
     id: project.id,
+    slug: project.slug,
     title: project.name,
     description: project.shortDescription,
     website: project.websiteUrl,
@@ -14,12 +18,15 @@ function toCardProps(project: ProjectMinimal) {
     topis: [project.category?.name, pricingLabels[project.pricing]].filter(
       Boolean
     ) as string[],
-    upCount: 0,
+    upCount: project.upvoteCount,
+    hasUpvoted: project.hasUpvoted,
   };
 }
 
 export function ProjectList() {
   const { data, isLoading, isError } = useProjects();
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const { toggleUpvote, pendingProjectId } = useToggleUpvote();
 
   if (isLoading) {
     return (
@@ -53,9 +60,21 @@ export function ProjectList() {
 
   return (
     <Stack gap={40}>
-      {data.data.map((project) => (
-        <Projectcard key={project.id} {...toCardProps(project)} />
+      {data.data.map((project, index) => (
+        <Projectcard
+          key={project.id}
+          {...toCardProps(project)}
+          onOpen={() => setSelectedIndex(index)}
+          onUpvote={() => toggleUpvote(project.id)}
+          isUpvotePending={pendingProjectId === project.id}
+        />
       ))}
+      <ProjectDetailModal
+        projects={data.data}
+        index={selectedIndex}
+        onIndexChange={setSelectedIndex}
+        onClose={() => setSelectedIndex(null)}
+      />
     </Stack>
   );
 }

--- a/web/src/modules/project-list/types/project.ts
+++ b/web/src/modules/project-list/types/project.ts
@@ -1,9 +1,11 @@
 export type Project = {
   id: number;
+  slug: string;
   iconUrl?: string;
   website: string;
   title: string;
   description: string;
   topis: string[];
   upCount: number;
+  hasUpvoted: boolean;
 };

--- a/web/src/modules/submit/ui/components/categories-diplay/categories-display.tsx
+++ b/web/src/modules/submit/ui/components/categories-diplay/categories-display.tsx
@@ -11,7 +11,9 @@ export function CategoriesDisplay({ label, badges }: CategoriesDisplayProps) {
       <Text fw={600}>{label}</Text>
       <Flex gap={"xs"}>
         {badges.map((badge) => (
-          <Badge variant="default">{badge}</Badge>
+          <Badge key={badge} variant="default">
+            {badge}
+          </Badge>
         ))}
       </Flex>
     </Stack>

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ProjectsSlugRouteImport } from './routes/projects/$slug'
 import { Route as AuthedOnboardingRouteImport } from './routes/_authed/onboarding'
 import { Route as AuthedDashboardRouteRouteImport } from './routes/_authed/dashboard/route'
 import { Route as AuthedDashboardSubmitRouteImport } from './routes/_authed/dashboard/submit'
@@ -23,6 +24,11 @@ const AuthedRoute = AuthedRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectsSlugRoute = ProjectsSlugRouteImport.update({
+  id: '/projects/$slug',
+  path: '/projects/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthedOnboardingRoute = AuthedOnboardingRouteImport.update({
@@ -50,6 +56,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dashboard': typeof AuthedDashboardRouteRouteWithChildren
   '/onboarding': typeof AuthedOnboardingRoute
+  '/projects/$slug': typeof ProjectsSlugRoute
   '/dashboard/releases': typeof AuthedDashboardReleasesRoute
   '/dashboard/submit': typeof AuthedDashboardSubmitRoute
 }
@@ -57,6 +64,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof AuthedDashboardRouteRouteWithChildren
   '/onboarding': typeof AuthedOnboardingRoute
+  '/projects/$slug': typeof ProjectsSlugRoute
   '/dashboard/releases': typeof AuthedDashboardReleasesRoute
   '/dashboard/submit': typeof AuthedDashboardSubmitRoute
 }
@@ -66,6 +74,7 @@ export interface FileRoutesById {
   '/_authed': typeof AuthedRouteWithChildren
   '/_authed/dashboard': typeof AuthedDashboardRouteRouteWithChildren
   '/_authed/onboarding': typeof AuthedOnboardingRoute
+  '/projects/$slug': typeof ProjectsSlugRoute
   '/_authed/dashboard/releases': typeof AuthedDashboardReleasesRoute
   '/_authed/dashboard/submit': typeof AuthedDashboardSubmitRoute
 }
@@ -75,6 +84,7 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/onboarding'
+    | '/projects/$slug'
     | '/dashboard/releases'
     | '/dashboard/submit'
   fileRoutesByTo: FileRoutesByTo
@@ -82,6 +92,7 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/onboarding'
+    | '/projects/$slug'
     | '/dashboard/releases'
     | '/dashboard/submit'
   id:
@@ -90,6 +101,7 @@ export interface FileRouteTypes {
     | '/_authed'
     | '/_authed/dashboard'
     | '/_authed/onboarding'
+    | '/projects/$slug'
     | '/_authed/dashboard/releases'
     | '/_authed/dashboard/submit'
   fileRoutesById: FileRoutesById
@@ -97,6 +109,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthedRoute: typeof AuthedRouteWithChildren
+  ProjectsSlugRoute: typeof ProjectsSlugRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -113,6 +126,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects/$slug': {
+      id: '/projects/$slug'
+      path: '/projects/$slug'
+      fullPath: '/projects/$slug'
+      preLoaderRoute: typeof ProjectsSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authed/onboarding': {
@@ -175,6 +195,7 @@ const AuthedRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthedRoute: AuthedRouteWithChildren,
+  ProjectsSlugRoute: ProjectsSlugRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web/src/routes/projects/$slug.tsx
+++ b/web/src/routes/projects/$slug.tsx
@@ -1,0 +1,47 @@
+import { Header } from "@/components/header/header";
+import { Page } from "@/layouts/page";
+import { useProject } from "@/modules/project-detail/hooks/use-project";
+import { ProjectDetailView } from "@/modules/project-detail/components/project-detail-view/project-detail-view";
+import { Anchor, Container, Skeleton, Stack, Text } from "@mantine/core";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { Link, createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/projects/$slug")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { slug } = Route.useParams();
+  const { data, isLoading, isError } = useProject(slug);
+
+  return (
+    <Page>
+      <Header />
+      <Container size={900} w={"100%"} py={"xl"}>
+        <Stack gap={"lg"}>
+          <Anchor component={Link} to="/" size="sm" c="dimmed">
+            <IconArrowLeft
+              size={14}
+              style={{ verticalAlign: "middle", marginRight: 4 }}
+            />
+            Voltar
+          </Anchor>
+
+          {isLoading && (
+            <Stack gap="lg">
+              <Skeleton h={32} w={280} />
+              <Skeleton h={280} radius="md" />
+            </Stack>
+          )}
+
+          {isError && (
+            <Text c="dimmed">Não foi possível carregar este projeto.</Text>
+          )}
+
+          {data && <ProjectDetailView project={data} />}
+        </Stack>
+      </Container>
+      {/* <Footer /> */}
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the upvote system and public project detail views. This is the baseline the
[MVP roadmap](specs/MVP.md) builds on, so it needs to land on `dev` before the roadmap work starts.

## API

- New `project_upvotes` table — unique per `(project_id, user_id)`, cascade deletes.
- `POST /v1/projects/:id/upvote` toggles the current user's vote and returns the fresh count.
- `GET /v1/projects/:slug` returns a project with its author.
- List endpoints now expose `upvoteCount` and `hasUpvoted`.

## Web

- Project detail modal with prev/next navigation and expand-to-page.
- `/projects/$slug` route reusing the shared detail view.
- Project card reads real vote data instead of local state.

## Fixes

- Confetti lifetime is a frame count, not milliseconds.
- Missing React key on category badges.

## Test plan

- [x] `pnpm --filter @hubdigital/api test` — E2E covers create/list/detail/upvote toggle
- [ ] Manual: upvote toggles and persists across reload
- [ ] Manual: `/projects/$slug` renders for a published project

🤖 Generated with [Claude Code](https://claude.com/claude-code)